### PR TITLE
KIEKER-1467 Replaced deprecated LaTeX command with recommended one.

### DIFF
--- a/kieker-documentation/userguide/Packages.tex
+++ b/kieker-documentation/userguide/Packages.tex
@@ -40,7 +40,7 @@
 
 % This package is for the directory tree structures
 \usepackage{dirtree}
-\renewcommand*\DTstylecomment{\footnotesize\it\rmfamily}
+\renewcommand*\DTstylecomment{\footnotesize\normalfont\itshape\rmfamily}
 \renewcommand*\DTstyle{\footnotesize\sffamily}
 
 % We need this package for some color within the document.


### PR DESCRIPTION
The said deprecated LaTeX commandhas been replaced and should solve the build failure issues for newer versions of LaTeX.