### PR TITLE
Fixed parsing errors for timestamp within data-bridge

### DIFF
--- a/kieker-tools/src/kieker/tools/bridge/connector/http/HTTPConnector.java
+++ b/kieker-tools/src/kieker/tools/bridge/connector/http/HTTPConnector.java
@@ -144,16 +144,15 @@ public final class HTTPConnector extends AbstractConnector {
 
 				// Extract the delivered values
 				final String classname = (String) jsonObject.get("class");
-				final String rawTimestamp = (String) jsonObject.get("timestamp");
+				final long timestamp = (Long) jsonObject.get("timestamp");
 				final Object[] rawValues = (Object[]) jsonObject.get("values");
 
-				if ((classname == null) || (rawTimestamp == null) || (rawValues == null)) {
+				if ((classname == null) || (rawValues == null)) {
 					LOG.warn("Invalid data received");
 					response.sendError(400, "Invalid data received");
 					return;
 				}
 
-				final long timestamp = Integer.parseInt(rawTimestamp);
 				final String[] values = Arrays.copyOf(rawValues, rawValues.length, String[].class);
 
 				// Try to deserialize a monitoring record from the given values


### PR DESCRIPTION
Hi there,

Just wanted to push these changes to the timestamp parsing upstream. 
The previous version caused an exception with valid incoming records.

Regards