### PR TITLE
build.gradle in root path: add property "failOnError = false" for apidoc task 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -466,6 +466,7 @@ task apidoc(type: Javadoc) {
     destinationDir = new File(projectDir, 'docs')
 
     title = "Kieker Monitoring and Analysis Framework, Vers. $kiekerVersion<br/>API Documentation"
+    failOnError = false
     options.header = "Kieker $kiekerVersion"
     options.footer = "Kieker $kiekerVersion"
     options.bottom = "Copyright " + year() + " $kiekerCopyright, <a href=\"http://kieker-monitoring.net\">http://kieker-monitoring.net</a>"


### PR DESCRIPTION
Javadoc style check failed will interrupt build process.
When these errors are ignored, the document will be generated correctly.