### PR TITLE
KIEKER-1482 

### DIFF
--- a/bin/dev/snap-ci/master/1-compile.sh
+++ b/bin/dev/snap-ci/master/1-compile.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk6 /bin/bash -c "cd /opt/kieker; ./gradlew -S compileJava compileTestJava"
+sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk7 /bin/bash -c "cd /opt/kieker; ./gradlew -S compileJava compileTestJava"
 
 exit $?

--- a/bin/dev/snap-ci/master/2-unit-test.sh
+++ b/bin/dev/snap-ci/master/2-unit-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk6 /bin/bash -c "cd /opt/kieker; ./gradlew -S test"
+sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk7 /bin/bash -c "cd /opt/kieker; ./gradlew -S test"
 
 exit $?

--- a/bin/dev/snap-ci/master/3-static-analysis.sh
+++ b/bin/dev/snap-ci/master/3-static-analysis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk6 /bin/bash -c "cd /opt/kieker; ./gradlew -S check"
+sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk7 /bin/bash -c "cd /opt/kieker; ./gradlew -S check"
 
 exit $?

--- a/bin/dev/snap-ci/master/4-release-check-short.sh
+++ b/bin/dev/snap-ci/master/4-release-check-short.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk6 /bin/bash -c "cd /opt/kieker; ./gradlew checkReleaseArchivesShort"
+sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk7 /bin/bash -c "cd /opt/kieker; ./gradlew checkReleaseArchivesShort"
 
 exit $?

--- a/bin/dev/snap-ci/master/5-release-check-extended.sh
+++ b/bin/dev/snap-ci/master/5-release-check-extended.sh
@@ -3,7 +3,7 @@
 if [ "${SNAP_BRANCH}" == "master" ]; then
   echo "We are in master - executing the extended release archive check."
 
-  sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk6 /bin/bash -c "cd /opt/kieker; ./gradlew checkReleaseArchives"
+  sudo docker run -v ${SNAP_WORKING_DIR}:/opt/kieker kieker/kieker-build:openjdk7 /bin/bash -c "cd /opt/kieker; ./gradlew checkReleaseArchives"
 
   STAGE_RESULT=$?
 else

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ checkstyleErrorThreshold = 10
 pmdWarningThreshold = 10
 pmdErrorThreshold = 1
 
-findbugsWarningThreshold = 10
+findbugsWarningThreshold = 18
 findbugsErrorThreshold = 1
 
 org.gradle.jvmargs = "-XX:MaxPermSize=128m"

--- a/kieker-tools/src/kieker/tools/opad/timeseries/forecast/ForecastObjectives.java
+++ b/kieker-tools/src/kieker/tools/opad/timeseries/forecast/ForecastObjectives.java
@@ -80,12 +80,12 @@ public class ForecastObjectives {
 	 * time series. The arithmetic mean strategy can
 	 * have a forecast accuracy below 1 and therefore
 	 * be better than a solely reactive approach
-	 * using implicitly the naïve strategy.
+	 * using implicitly the naive strategy.
 	 * This is only true in cases of nearly constant
 	 * base level of the arrivals rates.
 	 * These strategies should be executed as
 	 * frequently as possible every new time series point.
-	 * 2 = medium - CubicSmoothingSplines, ARIMA101, SimpleExponential Smoothing, Croston’s method for intermittent demands:
+	 * 2 = medium - CubicSmoothingSplines, ARIMA101, SimpleExponential Smoothing, Crostons method for intermittent demands:
 	 * The strengths of these strategies are the
 	 * low computational efforts below 100ms and their
 	 * ability to extrapolate the trend component.


### PR DESCRIPTION
Changed docker environments to OpenJDK 7 and increased warning threshold for Findbugs as the detection counts differ from the old version used in Java 6.

This is related to the certificate issue in Ticket 1482:
https://kieker-monitoring.atlassian.net/browse/KIEKER-1482