### PR TITLE
KIEKER-1519 removed workaround for SnapCI

### DIFF
--- a/bin/dev/release-check-short.sh
+++ b/bin/dev/release-check-short.sh
@@ -37,10 +37,6 @@ function assert_all_sh_scripts_executable {
     for sh in $(find -name "*.sh"); do
 	echo -n "Checking for exectuable flag: $sh ... "
 	if ! test -x $sh; then
-	    if [[ $sh =~ build-script-.*\.sh ]] ; then
-		echo "excluded (workaround for SnapCI, see Ticket 1519 - https://kieker-monitoring.atlassian.net/browse/KIEKER-1519)"
-		continue
-            fi
 	    echo " not executable"
 	    exit 1
 	fi


### PR DESCRIPTION
As SnapCI resolved the issue of the appearing non-executable shell-script file, the workaround is no longer needed and therefor removed.