### PR TITLE
KIEKER-1521 fixed

### DIFF
--- a/kieker-common/src/kieker/common/configuration/Configuration.java
+++ b/kieker-common/src/kieker/common/configuration/Configuration.java
@@ -64,7 +64,7 @@ public class Configuration extends Properties {
 	 * @param key
 	 *            The key of the property.
 	 *
-	 * @return A string with the value of the given property or null, if the property does not exist.
+	 * @return A string with the value of the given property or the empty string, if the property does not exist.
 	 */
 	public final String getStringProperty(final String key) {
 		return this.getStringProperty(key, "");
@@ -78,7 +78,7 @@ public class Configuration extends Properties {
 	 *
 	 * @param defaultValue
 	 *            The default value for the given <code>key</code>
-	 * 
+	 *
 	 * @return A string with the value of the given property or the given <code>defaultValue</code>, if the property does not exist.
 	 */
 	public final String getStringProperty(final String key, final String defaultValue) {

--- a/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
+++ b/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
@@ -177,247 +177,6 @@ kieker.monitoring.writer.PrintStreamWriter.Stream=STDOUT
 
 
 #####
-#kieker.monitoring.writer=kieker.monitoring.writer.filesystem.AsyncFsWriter
-#
-## In order to use a custom directory, set customStoragePath as desired. Examples:
-## /var/kieker or C:\\KiekerData (ensure the folder exists).
-## Otherwise the default temporary directory will be used
-kieker.monitoring.writer.filesystem.AsyncFsWriter.customStoragePath=
-#
-## The maximal number of entries (records) per created file.
-## Must be greater than zero.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.maxEntriesInFile=25000
-#
-## The maximal file size of the generated monitoring log. Older files will be 
-## deleted if this file size is exceeded. Given in MiB.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncFsWriter.maxLogSize=-1
-#
-## The maximal number of log files generated. Older files will be 
-## deleted if this number is exceeded.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncFsWriter.maxLogFiles=-1
-#
-## When flushing is disabled, it could require a lot of records before
-## finally any writing is done.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.flush=true
-#
-## When flushing is disabled, records are buffered in memory before written.
-## This setting configures the size of the used buffer in bytes.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.bufferSize=8192
-#
-## Asynchronous writers need to store monitoring records in an internal buffer.
-## This parameter defines its capacity in terms of the number of records. 
-kieker.monitoring.writer.filesystem.AsyncFsWriter.QueueSize=10000
-#
-## Asynchronous writers need to store specific monitoring records in a prioritized internal buffer.
-## This parameter defines its capacity in terms of the number of records.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.PrioritizedQueueSize=100
-
-## Behavior of the asynchronous writer when the internal queue is full:
-## 0: terminate Monitoring with an error (default)
-## 1: writer blocks until queue capacity is available
-## 2: writer discards new records until space is available
-##  Be careful when using the value '1' since then, the asynchronous writer
-##  is no longer decoupled from the monitored application.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.QueueFullBehavior=0
-#
-## Maximum time to wait for the writer threads to finish (in milliseconds).
-## A MaxShutdownDelay of -1 means infinite waiting.
-kieker.monitoring.writer.filesystem.AsyncFsWriter.MaxShutdownDelay=-1
-
-
-#####
-#kieker.monitoring.writer=kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter
-#
-## In order to use a custom directory, set customStoragePath as desired. Examples:
-## /var/kieker or C:\\KiekerData (ensure the folder exists).
-## Otherwise the default temporary directory will be used
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.customStoragePath=
-#
-## The maximal number of entries (records) per created file.
-## Must be greater than zero.
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.maxEntriesInFile=25000
-#
-## The maximal file size of the generated monitoring log. Older files will be 
-## deleted if this file size is exceeded. Given in MiB.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.maxLogSize=-1
-#
-## The maximal number of log files generated. Older files will be 
-## deleted if this number is exceeded.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.maxLogFiles=-1
-#
-## Whether the generated log files are compressed before writing to disk.
-## Supported values are: NONE, DEFLATE, GZIP, ZIP
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.compress=NONE
-#
-## Records are buffered in memory before written to disk.
-## This setting configures the size of the used buffer in bytes.
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.bufferSize=8192
-#
-## Asynchronous writers need to store monitoring records in an internal buffer.
-## This parameter defines its capacity in terms of the number of records. 
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.QueueSize=10000
-#
-## Asynchronous writers need to store specific monitoring records in a prioritized internal buffer.
-## This parameter defines its capacity in terms of the number of records.
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.PrioritizedQueueSize=100
-
-## Behavior of the asynchronous writer when the internal queue is full:
-## 0: terminate Monitoring with an error (default)
-## 1: writer blocks until queue capacity is available
-## 2: writer discards new records until space is available
-##  Be careful when using the value '1' since then, the asynchronous writer
-##  is no longer decoupled from the monitored application.
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.QueueFullBehavior=0
-#
-## Maximum time to wait for the writer threads to finish (in milliseconds).
-## A MaxShutdownDelay of -1 means infinite waiting.
-kieker.monitoring.writer.filesystem.AsyncBinaryFsWriter.MaxShutdownDelay=-1
-
-
-#####
-#kieker.monitoring.writer=kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter
-#
-## In order to use a custom directory, set customStoragePath as desired. Examples:
-## /var/kieker or C:\\KiekerData (ensure the folder exists).
-## Otherwise the default temporary directory will be used
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.customStoragePath=
-#
-## The maximal number of entries (records) per created file.
-## Must be greater than zero.
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.maxEntriesInFile=25000
-#
-## The maximal file size of the generated monitoring log. Older files will be 
-## deleted if this file size is exceeded. Given in MiB.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.maxLogSize=-1
-#
-## The maximal number of log files generated. Older files will be 
-## deleted if this number is exceeded.
-## At least one file will always remain, regardless of size!
-## Use -1 to ignore this functionality. 
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.maxLogFiles=-1
-#
-## Records are buffered in memory before written to disk.
-## This setting configures the size of the used buffer in bytes.
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.bufferSize=65535
-#
-## Asynchronous writers need to store monitoring records in an internal buffer.
-## This parameter defines its capacity in terms of the number of records. 
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.QueueSize=10000
-#
-## Asynchronous writers need to store specific monitoring records in a prioritized internal buffer.
-## This parameter defines its capacity in terms of the number of records.
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.PrioritizedQueueSize=100
-
-## Behavior of the asynchronous writer when the internal queue is full:
-## 0: terminate Monitoring with an error (default)
-## 1: writer blocks until queue capacity is available
-## 2: writer discards new records until space is available
-##  Be careful when using the value '1' since then, the asynchronous writer
-##  is no longer decoupled from the monitored application.
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.QueueFullBehavior=0
-#
-## Maximum time to wait for the writer threads to finish (in milliseconds).
-## A MaxShutdownDelay of -1 means infinite waiting.
-kieker.monitoring.writer.filesystem.AsyncBinaryNFsWriter.MaxShutdownDelay=-1
-
-
-#####
-#kieker.monitoring.writer=kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter
-#
-## In order to use a custom directory, set customStoragePath as desired. Examples:
-## /var/kieker or C:\\KiekerData (ensure the folder exists).
-## Otherwise the default temporary directory will be used
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.customStoragePath=
-#
-## The maximal number of entries (records) per created file.
-## Must be greater than zero.
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.maxEntriesInFile=25000
-#
-## Records are buffered in memory before written to disk.
-## This setting configures the size of the used buffer in bytes.
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.bufferSize=8192
-#
-## Asynchronous writers need to store monitoring records in an internal buffer.
-## This parameter defines its capacity in terms of the number of records. 
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.QueueSize=10000
-#
-## Asynchronous writers need to store specific monitoring records in a prioritized internal buffer.
-## This parameter defines its capacity in terms of the number of records.
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.PrioritizedQueueSize=100
-
-## Behavior of the asynchronous writer when the internal queue is full:
-## 0: terminate Monitoring with an error (default)
-## 1: writer blocks until queue capacity is available
-## 2: writer discards new records until space is available
-##  Be careful when using the value '1' since then, the asynchronous writer
-##  is no longer decoupled from the monitored application.
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.QueueFullBehavior=0
-#
-## Maximum time to wait for the writer threads to finish (in milliseconds).
-## A MaxShutdownDelay of -1 means infinite waiting.
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.MaxShutdownDelay=-1
-#
-## Sets the compression level. The only valid values are:
-## -1: default compression
-## 0: no compression
-## 1-9: from best speed to best compression 
-kieker.monitoring.writer.filesystem.AsyncAsciiZipWriter.compressionLevel=-1
-
-
-#####
-#kieker.monitoring.writer=kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter
-#
-## In order to use a custom directory, set customStoragePath as desired. Examples:
-## /var/kieker or C:\\KiekerData (ensure the folder exists).
-## Otherwise the default temporary directory will be used
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.customStoragePath=
-#
-## The maximal number of entries (records) per created file.
-## Must be greater than zero.
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.maxEntriesInFile=25000
-#
-## Records are buffered in memory before written to disk.
-## This setting configures the size of the used buffer in bytes.
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.bufferSize=8192
-#
-## Asynchronous writers need to store monitoring records in an internal buffer.
-## This parameter defines its capacity in terms of the number of records. 
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.QueueSize=10000
-#
-## Asynchronous writers need to store specific monitoring records in a prioritized internal buffer.
-## This parameter defines its capacity in terms of the number of records.
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.PrioritizedQueueSize=100
-
-## Behavior of the asynchronous writer when the internal queue is full:
-## 0: terminate Monitoring with an error (default)
-## 1: writer blocks until queue capacity is available
-## 2: writer discards new records until space is available
-##  Be careful when using the value '1' since then, the asynchronous writer
-##  is no longer decoupled from the monitored application.
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.QueueFullBehavior=0
-#
-## Maximum time to wait for the writer threads to finish (in milliseconds).
-## A MaxShutdownDelay of -1 means infinite waiting.
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.MaxShutdownDelay=-1
-#
-## Sets the compression level. The only valid values are:
-## -1: default compression
-## 0: no compression
-## 1-9: from best speed to best compression 
-kieker.monitoring.writer.filesystem.AsyncBinaryZipWriter.compressionLevel=-1
-
-
-#####
 #kieker.monitoring.writer=kieker.monitoring.writer.namedRecordPipe.PipeWriter
 #
 ## The name of the pipe used (must not be empty).
@@ -574,6 +333,15 @@ kieker.monitoring.writer.filesystem.AsciiFileWriter.maxLogFiles=-1
 ## When flushing is disabled, it could require a lot of records before
 ## finally any writing is done.
 kieker.monitoring.writer.filesystem.AsciiFileWriter.flush=false
+#
+## When compression is enabled, each log file is written as zipped ASCII file.
+kieker.monitoring.writer.filesystem.AsciiFileWriter.shouldCompress=false
+#
+## Sets the compression level. The only valid values are:
+## -1: default compression
+## 0: no compression
+## 1-9: from best speed to best compression 
+#kieker.monitoring.writer.filesystem.AsciiFileWriter.compressionLevel=-1
 
 #
 ## The maximal number of entries (records) per created file.
@@ -599,6 +367,13 @@ kieker.monitoring.writer.filesystem.BinaryFileWriter.flush=false
 ## When flushing is disabled, records are buffered in memory before written.
 ## This setting configures the size of the used buffer in bytes.
 kieker.monitoring.writer.filesystem.BinaryFileWriter.bufferSize=8192
-
-
+#
+## When compression is enabled, each log file is written as zipped binary file.
+kieker.monitoring.writer.filesystem.BinaryFileWriter.shouldCompress=false
+#
+## Sets the compression level. The only valid values are:
+## -1: default compression
+## 0: no compression
+## 1-9: from best speed to best compression 
+#kieker.monitoring.writer.filesystem.AsciiFileWriter.compressionLevel=-1
 

--- a/kieker-monitoring/src/kieker/monitoring/writer/filesystem/AsciiFileWriter.java
+++ b/kieker-monitoring/src/kieker/monitoring/writer/filesystem/AsciiFileWriter.java
@@ -16,6 +16,7 @@
 
 package kieker.monitoring.writer.filesystem;
 
+import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -65,7 +66,17 @@ public class AsciiFileWriter extends AbstractMonitoringWriter implements IRegist
 
 	public AsciiFileWriter(final Configuration configuration) {
 		super(configuration);
-		this.logFolder = KiekerLogFolder.buildKiekerLogFolder(configuration.getStringProperty(CONFIG_PATH), configuration);
+
+		String configPathName = configuration.getStringProperty(CONFIG_PATH);
+		if (configPathName.isEmpty()) { // if the property does not exist or if the path is empty
+			configPathName = System.getProperty("java.io.tmpdir");
+		}
+
+		if (!(new File(configPathName)).isDirectory()) {
+			throw new IllegalArgumentException("'" + configPathName + "' is not a directory.");
+		}
+
+		this.logFolder = KiekerLogFolder.buildKiekerLogFolder(configPathName, configuration);
 
 		try {
 			Files.createDirectories(this.logFolder);

--- a/kieker-monitoring/src/kieker/monitoring/writer/filesystem/BinaryFileWriter.java
+++ b/kieker-monitoring/src/kieker/monitoring/writer/filesystem/BinaryFileWriter.java
@@ -16,6 +16,7 @@
 
 package kieker.monitoring.writer.filesystem;
 
+import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -72,7 +73,17 @@ public class BinaryFileWriter extends AbstractMonitoringWriter implements IRegis
 
 	public BinaryFileWriter(final Configuration configuration) {
 		super(configuration);
-		this.logFolder = KiekerLogFolder.buildKiekerLogFolder(configuration.getStringProperty(CONFIG_PATH), configuration);
+
+		String configPathName = configuration.getStringProperty(CONFIG_PATH);
+		if (configPathName.isEmpty()) { // if the property does not exist or if the path is empty
+			configPathName = System.getProperty("java.io.tmpdir");
+		}
+
+		if (!(new File(configPathName)).isDirectory()) {
+			throw new IllegalArgumentException("'" + configPathName + "' is not a directory.");
+		}
+
+		this.logFolder = KiekerLogFolder.buildKiekerLogFolder(configPathName, configuration);
 
 		try {
 			Files.createDirectories(this.logFolder);

--- a/kieker-monitoring/test/kieker/monitoring/writer/filesystem/AsciiFileWriterTest.java
+++ b/kieker-monitoring/test/kieker/monitoring/writer/filesystem/AsciiFileWriterTest.java
@@ -17,6 +17,7 @@
 package kieker.monitoring.writer.filesystem;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 
 import org.hamcrest.CoreMatchers;
@@ -30,7 +31,6 @@ import kieker.common.configuration.Configuration;
 import kieker.common.record.misc.EmptyRecord;
 import kieker.common.util.filesystem.FileExtensionFilter;
 import kieker.monitoring.core.configuration.ConfigurationFactory;
-import kieker.monitoring.writer.filesystem.AsciiFileWriter;
 
 /**
  * @author Christian Wulf
@@ -218,6 +218,35 @@ public class AsciiFileWriterTest {
 			Assert.assertNotNull(recordFiles);
 			Assert.assertThat(reasonMessage, recordFiles.length, CoreMatchers.is(expectedNumRecordFiles));
 		}
+	}
+
+	@Test
+	public void testValidLogFolder() {
+		final String passedConfigPathName = this.tmpFolder.getRoot().getAbsolutePath();
+		this.configuration.setProperty(AsciiFileWriter.CONFIG_PATH, passedConfigPathName);
+		final AsciiFileWriter writer = new AsciiFileWriter(this.configuration);
+
+		Assert.assertThat(writer.getLogFolder().toAbsolutePath().toString(), CoreMatchers.startsWith(passedConfigPathName));
+	}
+
+	@Test
+	public void testEmptyConfigPath() {
+		final String passedConfigPathName = "";
+		this.configuration.setProperty(AsciiFileWriter.CONFIG_PATH, passedConfigPathName);
+		final AsciiFileWriter writer = new AsciiFileWriter(this.configuration);
+
+		final String defaultDir = System.getProperty("java.io.tmpdir");
+		Assert.assertThat(writer.getLogFolder().toAbsolutePath().toString(), CoreMatchers.startsWith(defaultDir));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNonDirectoryConfigPath() throws IOException {
+		final String passedConfigPathName = this.tmpFolder.newFile().getAbsolutePath();
+		this.configuration.setProperty(AsciiFileWriter.CONFIG_PATH, passedConfigPathName);
+		final AsciiFileWriter writer = new AsciiFileWriter(this.configuration);
+
+		final String defaultDir = System.getProperty("java.io.tmpdir");
+		Assert.assertThat(writer.getLogFolder().toAbsolutePath().toString(), CoreMatchers.startsWith(defaultDir));
 	}
 
 }


### PR DESCRIPTION
KIEKER-1521 fixed;
removed obsolete writer configuration options in kieker.monitoring.default.properties;

Added also tests for correct and incorrect config path values.