### PR TITLE
Reduced the thresholds for the static analysis tools

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,13 +11,13 @@ libAspectjVersion = 1.8.2
 libEmfVersion = 2.10.0.v20140514-1158
 libJctoolsVersion = 1.2.1
 
-checkstyleWarningThreshold = 10
-checkstyleErrorThreshold = 6
+checkstyleErrorThreshold = 3
+checkstyleWarningThreshold = 9
 
-pmdWarningThreshold = 3
+findbugsErrorThreshold = 0
+findbugsWarningThreshold = 5
+
 pmdErrorThreshold = 0
-
-findbugsWarningThreshold = 6
-findbugsErrorThreshold = 1
+pmdWarningThreshold = 0
 
 org.gradle.jvmargs = "-XX:MaxPermSize=128m"


### PR DESCRIPTION
Due to the reduced number of static analysis errors and warnings, the corresponding thresholds have been lowered.