### PR TITLE
code regeneration after TemplateGenerator (interfaces) fix.

### DIFF
--- a/kieker-common/model/records/flow/Flow.irl
+++ b/kieker-common/model/records/flow/Flow.irl
@@ -1,3 +1,18 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.flow
 
 import kieker.common.record.flow.trace.TraceMetadata
@@ -61,7 +76,7 @@ template IOperationRecord : IFlowRecord, IOperationSignature, IClassSignature
 @author 'Jan Waller' @since '1.6'
 template ITraceRecord : IFlowRecord {
 	//grouped by TraceMetadata.traceId traceId = -1
-	long traceId = -1
+	changeable long traceId = -1
 	int orderIndex = -1
 }
 

--- a/kieker-common/src-gen/kieker/common/record/database/AfterDatabaseEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/database/AfterDatabaseEvent.java
@@ -1,47 +1,61 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
 
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 import kieker.common.record.AbstractMonitoringRecord;
 import kieker.common.record.IMonitoringRecord;
+import kieker.common.record.io.IValueDeserializer;
+import kieker.common.record.io.IValueSerializer;
 import kieker.common.util.registry.IRegistry;
 
 import kieker.common.record.flow.IEventRecord;
 import kieker.common.record.flow.IFlowRecord;
 import kieker.common.record.flow.IClassSignature;
 import kieker.common.record.flow.ITraceRecord;
-import kieker.common.record.io.IValueDeserializer;
-import kieker.common.record.io.IValueSerializer;
 
 /**
- * @author Christian Zirkelbach (czi@informatik.uni-kiel.de) API compatibility:
- *         Kieker 1.10.0
+ * @author Christian Zirkelbach (czi@informatik.uni-kiel.de)
+ * API compatibility: Kieker 1.13.0
  * 
  * @since 1.14
  */
-public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory,
-		IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord {
+public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory, IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord {
 	private static final long serialVersionUID = -3115006839098290523L;
 
 	/** Descriptive definition of the serialization size of the record. */
 	public static final int SIZE = TYPE_SIZE_LONG // IEventRecord.timestamp
-			+ TYPE_SIZE_STRING // IClassSignature.classSignature
-			+ TYPE_SIZE_LONG // ITraceRecord.traceId
-			+ TYPE_SIZE_INT // ITraceRecord.orderIndex
-			+ TYPE_SIZE_STRING // AfterDatabaseEvent.returnType
-			+ TYPE_SIZE_STRING // AfterDatabaseEvent.returnValue
+			 + TYPE_SIZE_STRING // IClassSignature.classSignature
+			 + TYPE_SIZE_LONG // ITraceRecord.traceId
+			 + TYPE_SIZE_INT // ITraceRecord.orderIndex
+			 + TYPE_SIZE_STRING // AfterDatabaseEvent.returnType
+			 + TYPE_SIZE_STRING // AfterDatabaseEvent.returnValue
 	;
-
-	public static final Class<?>[] TYPES = { long.class, // IEventRecord.timestamp
-			String.class, // IClassSignature.classSignature
-			long.class, // ITraceRecord.traceId
-			int.class, // ITraceRecord.orderIndex
-			String.class, // AfterDatabaseEvent.returnType
-			String.class, // AfterDatabaseEvent.returnValue
+	
+	public static final Class<?>[] TYPES = {
+		long.class, // IEventRecord.timestamp
+		String.class, // IClassSignature.classSignature
+		long.class, // ITraceRecord.traceId
+		int.class, // ITraceRecord.orderIndex
+		String.class, // AfterDatabaseEvent.returnType
+		String.class, // AfterDatabaseEvent.returnValue
 	};
-
+	
+	
 	/** default constants. */
 	public static final long TIMESTAMP = 0L;
 	public static final String CLASS_SIGNATURE = "";
@@ -49,19 +63,25 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 	public static final int ORDER_INDEX = -1;
 	public static final String RETURN_TYPE = "";
 	public static final String RETURN_VALUE = "";
-
+	
 	/** property name array. */
-	private static final String[] PROPERTY_NAMES = { "timestamp", "classSignature", "traceId", "orderIndex",
-			"returnType", "returnValue", };
-
+	private static final String[] PROPERTY_NAMES = {
+		"timestamp",
+		"classSignature",
+		"traceId",
+		"orderIndex",
+		"returnType",
+		"returnValue",
+	};
+	
 	/** property declarations. */
 	private final long timestamp;
 	private final String classSignature;
-	private final long traceId;
+	private long traceId;
 	private final int orderIndex;
 	private final String returnType;
 	private final String returnValue;
-
+	
 	/**
 	 * Creates a new instance of this class using the given parameters.
 	 * 
@@ -78,25 +98,23 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 	 * @param returnValue
 	 *            returnValue
 	 */
-	public AfterDatabaseEvent(final long timestamp, final String classSignature, final long traceId,
-			final int orderIndex, final String returnType, final String returnValue) {
+	public AfterDatabaseEvent(final long timestamp, final String classSignature, final long traceId, final int orderIndex, final String returnType, final String returnValue) {
 		this.timestamp = timestamp;
-		this.classSignature = classSignature == null ? CLASS_SIGNATURE : classSignature;
+		this.classSignature = classSignature == null?CLASS_SIGNATURE:classSignature;
 		this.traceId = traceId;
 		this.orderIndex = orderIndex;
-		this.returnType = returnType == null ? "" : returnType;
-		this.returnValue = returnValue == null ? "" : returnValue;
+		this.returnType = returnType == null?"":returnType;
+		this.returnValue = returnValue == null?"":returnValue;
 	}
 
 	/**
-	 * This constructor converts the given array into a record. It is recommended to
-	 * use the array which is the result of a call to {@link #toArray()}.
+	 * This constructor converts the given array into a record.
+	 * It is recommended to use the array which is the result of a call to {@link #toArray()}.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 *
-	 * @deprecated since 1.13. Use {@link #AfterDatabaseEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #AfterDatabaseEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
 	public AfterDatabaseEvent(final Object[] values) { // NOPMD (direct store of values)
@@ -110,16 +128,14 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 	}
 
 	/**
-	 * This constructor uses the given array to initialize the fields of this
-	 * record.
+	 * This constructor uses the given array to initialize the fields of this record.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 * @param valueTypes
 	 *            The types of the elements in the first array.
 	 *
-	 * @deprecated since 1.13. Use {@link #AfterDatabaseEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #AfterDatabaseEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
 	protected AfterDatabaseEvent(final Object[] values, final Class<?>[] valueTypes) { // NOPMD (values stored directly)
@@ -132,145 +148,7 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 		this.returnValue = (String) values[5];
 	}
 
-	/**
-	 * This constructor converts the given buffer into a record.
-	 * 
-	 * @param buffer
-	 *            The bytes for the record
-	 * @param stringRegistry
-	 *            The string registry for deserialization
-	 * 
-	 * @throws BufferUnderflowException
-	 *             if buffer not sufficient
-	 *
-	 * @deprecated since 1.13. Use {@link #AfterDatabaseEvent(IValueDeserializer)}
-	 *             instead.
-	 */
-	@Deprecated
-	public AfterDatabaseEvent(final ByteBuffer buffer, final IRegistry<String> stringRegistry)
-			throws BufferUnderflowException {
-		this.timestamp = buffer.getLong();
-		this.classSignature = stringRegistry.get(buffer.getInt());
-		this.traceId = buffer.getLong();
-		this.orderIndex = buffer.getInt();
-		this.returnType = stringRegistry.get(buffer.getInt());
-		this.returnValue = stringRegistry.get(buffer.getInt());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an
-	 *             array serializer instead.
-	 */
-	@Override
-	@Deprecated
-	public Object[] toArray() {
-		return new Object[] { this.getTimestamp(), this.getClassSignature(), this.getTraceId(), this.getOrderIndex(),
-				this.getReturnType(), this.getReturnValue() };
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void registerStrings(final IRegistry<String> stringRegistry) { // NOPMD (generated code)
-		stringRegistry.get(this.getClassSignature());
-		stringRegistry.get(this.getReturnType());
-		stringRegistry.get(this.getReturnValue());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Class<?>[] getValueTypes() {
-		return TYPES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String[] getValueNames() {
-		return PROPERTY_NAMES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getSize() {
-		return SIZE;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @deprecated This record uses the
-	 *             {@link kieker.common.record.IMonitoringRecord.Factory} mechanism.
-	 *             Hence, this method is not implemented.
-	 */
-	@Override
-	@Deprecated
-	public void initFromArray(final Object[] values) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean equals(final Object obj) {
-		if (obj == null)
-			return false;
-		if (obj == this)
-			return true;
-		if (obj.getClass() != this.getClass())
-			return false;
-
-		final AfterDatabaseEvent castedRecord = (AfterDatabaseEvent) obj;
-		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp())
-			return false;
-		if (this.getTimestamp() != castedRecord.getTimestamp())
-			return false;
-		if (!this.getClassSignature().equals(castedRecord.getClassSignature()))
-			return false;
-		if (this.getTraceId() != castedRecord.getTraceId())
-			return false;
-		if (this.getOrderIndex() != castedRecord.getOrderIndex())
-			return false;
-		if (!this.getReturnType().equals(castedRecord.getReturnType()))
-			return false;
-		if (!this.getReturnValue().equals(castedRecord.getReturnValue()))
-			return false;
-		return true;
-	}
-
-	public final long getTimestamp() {
-		return this.timestamp;
-	}
-
-	public final String getClassSignature() {
-		return this.classSignature;
-	}
-
-	public final long getTraceId() {
-		return this.traceId;
-	}
-
-	public final int getOrderIndex() {
-		return this.orderIndex;
-	}
-
-	public final String getReturnType() {
-		return this.returnType;
-	}
-
-	public final String getReturnValue() {
-		return this.returnValue;
-	}
-
+	
 	/**
 	 * @param deserializer
 	 *            The deserializer to use
@@ -283,9 +161,39 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 		this.returnType = deserializer.getString();
 		this.returnValue = deserializer.getString();
 	}
-
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an array serializer instead.
+	 */
 	@Override
-	public void serialize(IValueSerializer serializer) throws BufferOverflowException {
+	@Deprecated
+	public Object[] toArray() {
+		return new Object[] {
+			this.getTimestamp(),
+			this.getClassSignature(),
+			this.getTraceId(),
+			this.getOrderIndex(),
+			this.getReturnType(),
+			this.getReturnValue()
+		};
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
+		stringRegistry.get(this.getClassSignature());
+		stringRegistry.get(this.getReturnType());
+		stringRegistry.get(this.getReturnValue());
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void serialize(final IValueSerializer serializer) throws BufferOverflowException {
+		//super.serialize(serializer);
 		serializer.putLong(this.getTimestamp());
 		serializer.putString(this.getClassSignature());
 		serializer.putLong(this.getTraceId());
@@ -293,5 +201,91 @@ public class AfterDatabaseEvent extends AbstractMonitoringRecord implements IMon
 		serializer.putString(this.getReturnType());
 		serializer.putString(this.getReturnValue());
 	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<?>[] getValueTypes() {
+		return TYPES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] getValueNames() {
+		return PROPERTY_NAMES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int getSize() {
+		return SIZE;
+	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @deprecated This record uses the {@link kieker.common.record.IMonitoringRecord.Factory} mechanism. Hence, this method is not implemented.
+	 */
+	@Override
+	@Deprecated
+	public void initFromArray(final Object[] values) {
+		throw new UnsupportedOperationException();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(final Object obj) {
+		if (obj == null) return false;
+		if (obj == this) return true;
+		if (obj.getClass() != this.getClass()) return false;
+		
+		final AfterDatabaseEvent castedRecord = (AfterDatabaseEvent) obj;
+		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp()) return false;
+		if (this.getTimestamp() != castedRecord.getTimestamp()) return false;
+		if (!this.getClassSignature().equals(castedRecord.getClassSignature())) return false;
+		if (this.getTraceId() != castedRecord.getTraceId()) return false;
+		if (this.getOrderIndex() != castedRecord.getOrderIndex()) return false;
+		if (!this.getReturnType().equals(castedRecord.getReturnType())) return false;
+		if (!this.getReturnValue().equals(castedRecord.getReturnValue())) return false;
+		return true;
+	}
+	
+	public final long getTimestamp() {
+		return this.timestamp;
+	}
+	
+	
+	public final String getClassSignature() {
+		return this.classSignature;
+	}
+	
+	
+	public final long getTraceId() {
+		return this.traceId;
+	}
+	
+	public final void setTraceId(long traceId) {
+		this.traceId = traceId;
+	}
+	
+	public final int getOrderIndex() {
+		return this.orderIndex;
+	}
+	
+	
+	public final String getReturnType() {
+		return this.returnType;
+	}
+	
+	
+	public final String getReturnValue() {
+		return this.returnValue;
+	}
+	
 }

--- a/kieker-common/src-gen/kieker/common/record/database/AfterDatabaseEventFactory.java
+++ b/kieker-common/src-gen/kieker/common/record/database/AfterDatabaseEventFactory.java
@@ -1,4 +1,20 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
+
 
 import kieker.common.record.factory.IRecordFactory;
 import kieker.common.record.io.IValueDeserializer;
@@ -9,18 +25,19 @@ import kieker.common.record.io.IValueDeserializer;
  * @since 1.14
  */
 public final class AfterDatabaseEventFactory implements IRecordFactory<AfterDatabaseEvent> {
-
+	
+	
 	@Override
-	public AfterDatabaseEvent create(IValueDeserializer deserializer) {
+	public AfterDatabaseEvent create(final IValueDeserializer deserializer) {
 		return new AfterDatabaseEvent(deserializer);
 	}
-
+	
 	@Override
 	@Deprecated
 	public AfterDatabaseEvent create(final Object[] values) {
 		return new AfterDatabaseEvent(values);
 	}
-
+	
 	public int getRecordSizeInBytes() {
 		return AfterDatabaseEvent.SIZE;
 	}

--- a/kieker-common/src-gen/kieker/common/record/database/BeforeDatabaseEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/database/BeforeDatabaseEvent.java
@@ -1,47 +1,61 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
 
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 import kieker.common.record.AbstractMonitoringRecord;
 import kieker.common.record.IMonitoringRecord;
+import kieker.common.record.io.IValueDeserializer;
+import kieker.common.record.io.IValueSerializer;
 import kieker.common.util.registry.IRegistry;
 
 import kieker.common.record.flow.IEventRecord;
 import kieker.common.record.flow.IFlowRecord;
 import kieker.common.record.flow.IClassSignature;
 import kieker.common.record.flow.ITraceRecord;
-import kieker.common.record.io.IValueDeserializer;
-import kieker.common.record.io.IValueSerializer;
 
 /**
- * @author Christian Zirkelbach (czi@informatik.uni-kiel.de) API compatibility:
- *         Kieker 1.10.0
+ * @author Christian Zirkelbach (czi@informatik.uni-kiel.de)
+ * API compatibility: Kieker 1.13.0
  * 
  * @since 1.14
  */
-public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory,
-		IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord {
+public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory, IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord {
 	private static final long serialVersionUID = -2138603925245500796L;
 
 	/** Descriptive definition of the serialization size of the record. */
 	public static final int SIZE = TYPE_SIZE_LONG // IEventRecord.timestamp
-			+ TYPE_SIZE_STRING // IClassSignature.classSignature
-			+ TYPE_SIZE_LONG // ITraceRecord.traceId
-			+ TYPE_SIZE_INT // ITraceRecord.orderIndex
-			+ TYPE_SIZE_STRING // BeforeDatabaseEvent.parameters
-			+ TYPE_SIZE_STRING // BeforeDatabaseEvent.technology
+			 + TYPE_SIZE_STRING // IClassSignature.classSignature
+			 + TYPE_SIZE_LONG // ITraceRecord.traceId
+			 + TYPE_SIZE_INT // ITraceRecord.orderIndex
+			 + TYPE_SIZE_STRING // BeforeDatabaseEvent.parameters
+			 + TYPE_SIZE_STRING // BeforeDatabaseEvent.technology
 	;
-
-	public static final Class<?>[] TYPES = { long.class, // IEventRecord.timestamp
-			String.class, // IClassSignature.classSignature
-			long.class, // ITraceRecord.traceId
-			int.class, // ITraceRecord.orderIndex
-			String.class, // BeforeDatabaseEvent.parameters
-			String.class, // BeforeDatabaseEvent.technology
+	
+	public static final Class<?>[] TYPES = {
+		long.class, // IEventRecord.timestamp
+		String.class, // IClassSignature.classSignature
+		long.class, // ITraceRecord.traceId
+		int.class, // ITraceRecord.orderIndex
+		String.class, // BeforeDatabaseEvent.parameters
+		String.class, // BeforeDatabaseEvent.technology
 	};
-
+	
+	
 	/** default constants. */
 	public static final long TIMESTAMP = 0L;
 	public static final String CLASS_SIGNATURE = "";
@@ -49,19 +63,25 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 	public static final int ORDER_INDEX = -1;
 	public static final String PARAMETERS = "";
 	public static final String TECHNOLOGY = "";
-
+	
 	/** property name array. */
-	private static final String[] PROPERTY_NAMES = { "timestamp", "classSignature", "traceId", "orderIndex",
-			"parameters", "technology", };
-
+	private static final String[] PROPERTY_NAMES = {
+		"timestamp",
+		"classSignature",
+		"traceId",
+		"orderIndex",
+		"parameters",
+		"technology",
+	};
+	
 	/** property declarations. */
 	private final long timestamp;
 	private final String classSignature;
-	private final long traceId;
+	private long traceId;
 	private final int orderIndex;
 	private final String parameters;
 	private final String technology;
-
+	
 	/**
 	 * Creates a new instance of this class using the given parameters.
 	 * 
@@ -78,25 +98,23 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 	 * @param technology
 	 *            technology
 	 */
-	public BeforeDatabaseEvent(final long timestamp, final String classSignature, final long traceId,
-			final int orderIndex, final String parameters, final String technology) {
+	public BeforeDatabaseEvent(final long timestamp, final String classSignature, final long traceId, final int orderIndex, final String parameters, final String technology) {
 		this.timestamp = timestamp;
-		this.classSignature = classSignature == null ? CLASS_SIGNATURE : classSignature;
+		this.classSignature = classSignature == null?CLASS_SIGNATURE:classSignature;
 		this.traceId = traceId;
 		this.orderIndex = orderIndex;
-		this.parameters = parameters == null ? "" : parameters;
-		this.technology = technology == null ? "" : technology;
+		this.parameters = parameters == null?"":parameters;
+		this.technology = technology == null?"":technology;
 	}
 
 	/**
-	 * This constructor converts the given array into a record. It is recommended to
-	 * use the array which is the result of a call to {@link #toArray()}.
+	 * This constructor converts the given array into a record.
+	 * It is recommended to use the array which is the result of a call to {@link #toArray()}.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 *
-	 * @deprecated since 1.13. Use {@link #BeforeDatabaseEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #BeforeDatabaseEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
 	public BeforeDatabaseEvent(final Object[] values) { // NOPMD (direct store of values)
@@ -110,20 +128,17 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 	}
 
 	/**
-	 * This constructor uses the given array to initialize the fields of this
-	 * record.
+	 * This constructor uses the given array to initialize the fields of this record.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 * @param valueTypes
 	 *            The types of the elements in the first array.
 	 *
-	 * @deprecated since 1.13. Use {@link #BeforeDatabaseEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #BeforeDatabaseEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
-	protected BeforeDatabaseEvent(final Object[] values, final Class<?>[] valueTypes) { // NOPMD (values stored
-																						// directly)
+	protected BeforeDatabaseEvent(final Object[] values, final Class<?>[] valueTypes) { // NOPMD (values stored directly)
 		AbstractMonitoringRecord.checkArray(values, valueTypes);
 		this.timestamp = (Long) values[0];
 		this.classSignature = (String) values[1];
@@ -133,145 +148,7 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 		this.technology = (String) values[5];
 	}
 
-	/**
-	 * This constructor converts the given buffer into a record.
-	 * 
-	 * @param buffer
-	 *            The bytes for the record
-	 * @param stringRegistry
-	 *            The string registry for deserialization
-	 * 
-	 * @throws BufferUnderflowException
-	 *             if buffer not sufficient
-	 *
-	 * @deprecated since 1.13. Use {@link #BeforeDatabaseEvent(IValueDeserializer)}
-	 *             instead.
-	 */
-	@Deprecated
-	public BeforeDatabaseEvent(final ByteBuffer buffer, final IRegistry<String> stringRegistry)
-			throws BufferUnderflowException {
-		this.timestamp = buffer.getLong();
-		this.classSignature = stringRegistry.get(buffer.getInt());
-		this.traceId = buffer.getLong();
-		this.orderIndex = buffer.getInt();
-		this.parameters = stringRegistry.get(buffer.getInt());
-		this.technology = stringRegistry.get(buffer.getInt());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an
-	 *             array serializer instead.
-	 */
-	@Override
-	@Deprecated
-	public Object[] toArray() {
-		return new Object[] { this.getTimestamp(), this.getClassSignature(), this.getTraceId(), this.getOrderIndex(),
-				this.getParameters(), this.getTechnology() };
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void registerStrings(final IRegistry<String> stringRegistry) { // NOPMD (generated code)
-		stringRegistry.get(this.getClassSignature());
-		stringRegistry.get(this.getParameters());
-		stringRegistry.get(this.getTechnology());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Class<?>[] getValueTypes() {
-		return TYPES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String[] getValueNames() {
-		return PROPERTY_NAMES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getSize() {
-		return SIZE;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @deprecated This record uses the
-	 *             {@link kieker.common.record.IMonitoringRecord.Factory} mechanism.
-	 *             Hence, this method is not implemented.
-	 */
-	@Override
-	@Deprecated
-	public void initFromArray(final Object[] values) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean equals(final Object obj) {
-		if (obj == null)
-			return false;
-		if (obj == this)
-			return true;
-		if (obj.getClass() != this.getClass())
-			return false;
-
-		final BeforeDatabaseEvent castedRecord = (BeforeDatabaseEvent) obj;
-		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp())
-			return false;
-		if (this.getTimestamp() != castedRecord.getTimestamp())
-			return false;
-		if (!this.getClassSignature().equals(castedRecord.getClassSignature()))
-			return false;
-		if (this.getTraceId() != castedRecord.getTraceId())
-			return false;
-		if (this.getOrderIndex() != castedRecord.getOrderIndex())
-			return false;
-		if (!this.getParameters().equals(castedRecord.getParameters()))
-			return false;
-		if (!this.getTechnology().equals(castedRecord.getTechnology()))
-			return false;
-		return true;
-	}
-
-	public final long getTimestamp() {
-		return this.timestamp;
-	}
-
-	public final String getClassSignature() {
-		return this.classSignature;
-	}
-
-	public final long getTraceId() {
-		return this.traceId;
-	}
-
-	public final int getOrderIndex() {
-		return this.orderIndex;
-	}
-
-	public final String getParameters() {
-		return this.parameters;
-	}
-
-	public final String getTechnology() {
-		return this.technology;
-	}
-
+	
 	/**
 	 * @param deserializer
 	 *            The deserializer to use
@@ -284,9 +161,39 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 		this.parameters = deserializer.getString();
 		this.technology = deserializer.getString();
 	}
-
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an array serializer instead.
+	 */
 	@Override
-	public void serialize(IValueSerializer serializer) throws BufferOverflowException {
+	@Deprecated
+	public Object[] toArray() {
+		return new Object[] {
+			this.getTimestamp(),
+			this.getClassSignature(),
+			this.getTraceId(),
+			this.getOrderIndex(),
+			this.getParameters(),
+			this.getTechnology()
+		};
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
+		stringRegistry.get(this.getClassSignature());
+		stringRegistry.get(this.getParameters());
+		stringRegistry.get(this.getTechnology());
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void serialize(final IValueSerializer serializer) throws BufferOverflowException {
+		//super.serialize(serializer);
 		serializer.putLong(this.getTimestamp());
 		serializer.putString(this.getClassSignature());
 		serializer.putLong(this.getTraceId());
@@ -294,5 +201,91 @@ public class BeforeDatabaseEvent extends AbstractMonitoringRecord implements IMo
 		serializer.putString(this.getParameters());
 		serializer.putString(this.getTechnology());
 	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<?>[] getValueTypes() {
+		return TYPES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] getValueNames() {
+		return PROPERTY_NAMES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int getSize() {
+		return SIZE;
+	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @deprecated This record uses the {@link kieker.common.record.IMonitoringRecord.Factory} mechanism. Hence, this method is not implemented.
+	 */
+	@Override
+	@Deprecated
+	public void initFromArray(final Object[] values) {
+		throw new UnsupportedOperationException();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(final Object obj) {
+		if (obj == null) return false;
+		if (obj == this) return true;
+		if (obj.getClass() != this.getClass()) return false;
+		
+		final BeforeDatabaseEvent castedRecord = (BeforeDatabaseEvent) obj;
+		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp()) return false;
+		if (this.getTimestamp() != castedRecord.getTimestamp()) return false;
+		if (!this.getClassSignature().equals(castedRecord.getClassSignature())) return false;
+		if (this.getTraceId() != castedRecord.getTraceId()) return false;
+		if (this.getOrderIndex() != castedRecord.getOrderIndex()) return false;
+		if (!this.getParameters().equals(castedRecord.getParameters())) return false;
+		if (!this.getTechnology().equals(castedRecord.getTechnology())) return false;
+		return true;
+	}
+	
+	public final long getTimestamp() {
+		return this.timestamp;
+	}
+	
+	
+	public final String getClassSignature() {
+		return this.classSignature;
+	}
+	
+	
+	public final long getTraceId() {
+		return this.traceId;
+	}
+	
+	public final void setTraceId(long traceId) {
+		this.traceId = traceId;
+	}
+	
+	public final int getOrderIndex() {
+		return this.orderIndex;
+	}
+	
+	
+	public final String getParameters() {
+		return this.parameters;
+	}
+	
+	
+	public final String getTechnology() {
+		return this.technology;
+	}
+	
 }

--- a/kieker-common/src-gen/kieker/common/record/database/BeforeDatabaseEventFactory.java
+++ b/kieker-common/src-gen/kieker/common/record/database/BeforeDatabaseEventFactory.java
@@ -1,4 +1,20 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
+
 
 import kieker.common.record.factory.IRecordFactory;
 import kieker.common.record.io.IValueDeserializer;
@@ -9,18 +25,19 @@ import kieker.common.record.io.IValueDeserializer;
  * @since 1.14
  */
 public final class BeforeDatabaseEventFactory implements IRecordFactory<BeforeDatabaseEvent> {
-
+	
+	
 	@Override
-	public BeforeDatabaseEvent create(IValueDeserializer deserializer) {
+	public BeforeDatabaseEvent create(final IValueDeserializer deserializer) {
 		return new BeforeDatabaseEvent(deserializer);
 	}
-
+	
 	@Override
 	@Deprecated
 	public BeforeDatabaseEvent create(final Object[] values) {
 		return new BeforeDatabaseEvent(values);
 	}
-
+	
 	public int getRecordSizeInBytes() {
 		return BeforeDatabaseEvent.SIZE;
 	}

--- a/kieker-common/src-gen/kieker/common/record/database/DatabaseFailedEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/database/DatabaseFailedEvent.java
@@ -1,63 +1,83 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
 
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 import kieker.common.record.AbstractMonitoringRecord;
 import kieker.common.record.IMonitoringRecord;
+import kieker.common.record.io.IValueDeserializer;
+import kieker.common.record.io.IValueSerializer;
 import kieker.common.util.registry.IRegistry;
 
 import kieker.common.record.flow.IEventRecord;
 import kieker.common.record.flow.IFlowRecord;
 import kieker.common.record.flow.IClassSignature;
 import kieker.common.record.flow.ITraceRecord;
-import kieker.common.record.io.IValueDeserializer;
-import kieker.common.record.io.IValueSerializer;
 import kieker.common.record.flow.IExceptionRecord;
 
 /**
- * @author Christian Zirkelbach (czi@informatik.uni-kiel.de) API compatibility:
- *         Kieker 1.10.0
+ * @author Christian Zirkelbach (czi@informatik.uni-kiel.de)
+ * API compatibility: Kieker 1.13.0
  * 
  * @since 1.14
  */
-public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory,
-		IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord, IExceptionRecord {
+public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMonitoringRecord.Factory, IMonitoringRecord.BinaryFactory, IEventRecord, IFlowRecord, IClassSignature, ITraceRecord, IExceptionRecord {
 	private static final long serialVersionUID = -8915416625127757824L;
 
 	/** Descriptive definition of the serialization size of the record. */
 	public static final int SIZE = TYPE_SIZE_LONG // IEventRecord.timestamp
-			+ TYPE_SIZE_STRING // IClassSignature.classSignature
-			+ TYPE_SIZE_LONG // ITraceRecord.traceId
-			+ TYPE_SIZE_INT // ITraceRecord.orderIndex
-			+ TYPE_SIZE_STRING // IExceptionRecord.cause
+			 + TYPE_SIZE_STRING // IClassSignature.classSignature
+			 + TYPE_SIZE_LONG // ITraceRecord.traceId
+			 + TYPE_SIZE_INT // ITraceRecord.orderIndex
+			 + TYPE_SIZE_STRING // IExceptionRecord.cause
 	;
-
-	public static final Class<?>[] TYPES = { long.class, // IEventRecord.timestamp
-			String.class, // IClassSignature.classSignature
-			long.class, // ITraceRecord.traceId
-			int.class, // ITraceRecord.orderIndex
-			String.class, // IExceptionRecord.cause
+	
+	public static final Class<?>[] TYPES = {
+		long.class, // IEventRecord.timestamp
+		String.class, // IClassSignature.classSignature
+		long.class, // ITraceRecord.traceId
+		int.class, // ITraceRecord.orderIndex
+		String.class, // IExceptionRecord.cause
 	};
-
+	
+	
 	/** default constants. */
 	public static final long TIMESTAMP = 0L;
 	public static final String CLASS_SIGNATURE = "";
 	public static final long TRACE_ID = -1L;
 	public static final int ORDER_INDEX = -1;
 	public static final String CAUSE = "";
-
+	
 	/** property name array. */
-	private static final String[] PROPERTY_NAMES = { "timestamp", "classSignature", "traceId", "orderIndex", "cause", };
-
+	private static final String[] PROPERTY_NAMES = {
+		"timestamp",
+		"classSignature",
+		"traceId",
+		"orderIndex",
+		"cause",
+	};
+	
 	/** property declarations. */
 	private final long timestamp;
 	private final String classSignature;
-	private final long traceId;
+	private long traceId;
 	private final int orderIndex;
 	private final String cause;
-
+	
 	/**
 	 * Creates a new instance of this class using the given parameters.
 	 * 
@@ -72,24 +92,22 @@ public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMo
 	 * @param cause
 	 *            cause
 	 */
-	public DatabaseFailedEvent(final long timestamp, final String classSignature, final long traceId,
-			final int orderIndex, final String cause) {
+	public DatabaseFailedEvent(final long timestamp, final String classSignature, final long traceId, final int orderIndex, final String cause) {
 		this.timestamp = timestamp;
-		this.classSignature = classSignature == null ? CLASS_SIGNATURE : classSignature;
+		this.classSignature = classSignature == null?CLASS_SIGNATURE:classSignature;
 		this.traceId = traceId;
 		this.orderIndex = orderIndex;
-		this.cause = cause == null ? CAUSE : cause;
+		this.cause = cause == null?CAUSE:cause;
 	}
 
 	/**
-	 * This constructor converts the given array into a record. It is recommended to
-	 * use the array which is the result of a call to {@link #toArray()}.
+	 * This constructor converts the given array into a record.
+	 * It is recommended to use the array which is the result of a call to {@link #toArray()}.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 *
-	 * @deprecated since 1.13. Use {@link #DatabaseFailedEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #DatabaseFailedEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
 	public DatabaseFailedEvent(final Object[] values) { // NOPMD (direct store of values)
@@ -102,20 +120,17 @@ public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMo
 	}
 
 	/**
-	 * This constructor uses the given array to initialize the fields of this
-	 * record.
+	 * This constructor uses the given array to initialize the fields of this record.
 	 * 
 	 * @param values
 	 *            The values for the record.
 	 * @param valueTypes
 	 *            The types of the elements in the first array.
 	 *
-	 * @deprecated since 1.13. Use {@link #DatabaseFailedEvent(IValueDeserializer)}
-	 *             instead.
+	 * @deprecated since 1.13. Use {@link #DatabaseFailedEvent(IValueDeserializer)} instead.
 	 */
 	@Deprecated
-	protected DatabaseFailedEvent(final Object[] values, final Class<?>[] valueTypes) { // NOPMD (values stored
-																						// directly)
+	protected DatabaseFailedEvent(final Object[] values, final Class<?>[] valueTypes) { // NOPMD (values stored directly)
 		AbstractMonitoringRecord.checkArray(values, valueTypes);
 		this.timestamp = (Long) values[0];
 		this.classSignature = (String) values[1];
@@ -124,137 +139,7 @@ public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMo
 		this.cause = (String) values[4];
 	}
 
-	/**
-	 * This constructor converts the given buffer into a record.
-	 * 
-	 * @param buffer
-	 *            The bytes for the record
-	 * @param stringRegistry
-	 *            The string registry for deserialization
-	 * 
-	 * @throws BufferUnderflowException
-	 *             if buffer not sufficient
-	 *
-	 * @deprecated since 1.13. Use {@link #DatabaseFailedEvent(IValueDeserializer)}
-	 *             instead.
-	 */
-	@Deprecated
-	public DatabaseFailedEvent(final ByteBuffer buffer, final IRegistry<String> stringRegistry)
-			throws BufferUnderflowException {
-		this.timestamp = buffer.getLong();
-		this.classSignature = stringRegistry.get(buffer.getInt());
-		this.traceId = buffer.getLong();
-		this.orderIndex = buffer.getInt();
-		this.cause = stringRegistry.get(buffer.getInt());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an
-	 *             array serializer instead.
-	 */
-	@Override
-	@Deprecated
-	public Object[] toArray() {
-		return new Object[] { this.getTimestamp(), this.getClassSignature(), this.getTraceId(), this.getOrderIndex(),
-				this.getCause() };
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void registerStrings(final IRegistry<String> stringRegistry) { // NOPMD (generated code)
-		stringRegistry.get(this.getClassSignature());
-		stringRegistry.get(this.getCause());
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Class<?>[] getValueTypes() {
-		return TYPES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String[] getValueNames() {
-		return PROPERTY_NAMES; // NOPMD
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getSize() {
-		return SIZE;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @deprecated This record uses the
-	 *             {@link kieker.common.record.IMonitoringRecord.Factory} mechanism.
-	 *             Hence, this method is not implemented.
-	 */
-	@Override
-	@Deprecated
-	public void initFromArray(final Object[] values) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean equals(final Object obj) {
-		if (obj == null)
-			return false;
-		if (obj == this)
-			return true;
-		if (obj.getClass() != this.getClass())
-			return false;
-
-		final DatabaseFailedEvent castedRecord = (DatabaseFailedEvent) obj;
-		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp())
-			return false;
-		if (this.getTimestamp() != castedRecord.getTimestamp())
-			return false;
-		if (!this.getClassSignature().equals(castedRecord.getClassSignature()))
-			return false;
-		if (this.getTraceId() != castedRecord.getTraceId())
-			return false;
-		if (this.getOrderIndex() != castedRecord.getOrderIndex())
-			return false;
-		if (!this.getCause().equals(castedRecord.getCause()))
-			return false;
-		return true;
-	}
-
-	public final long getTimestamp() {
-		return this.timestamp;
-	}
-
-	public final String getClassSignature() {
-		return this.classSignature;
-	}
-
-	public final long getTraceId() {
-		return this.traceId;
-	}
-
-	public final int getOrderIndex() {
-		return this.orderIndex;
-	}
-
-	public final String getCause() {
-		return this.cause;
-	}
-
+	
 	/**
 	 * @param deserializer
 	 *            The deserializer to use
@@ -266,14 +151,122 @@ public class DatabaseFailedEvent extends AbstractMonitoringRecord implements IMo
 		this.orderIndex = deserializer.getInt();
 		this.cause = deserializer.getString();
 	}
-
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated since 1.13. Use {@link #serialize(IValueSerializer)} with an array serializer instead.
+	 */
 	@Override
-	public void serialize(IValueSerializer serializer) throws BufferOverflowException {
+	@Deprecated
+	public Object[] toArray() {
+		return new Object[] {
+			this.getTimestamp(),
+			this.getClassSignature(),
+			this.getTraceId(),
+			this.getOrderIndex(),
+			this.getCause()
+		};
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
+		stringRegistry.get(this.getClassSignature());
+		stringRegistry.get(this.getCause());
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void serialize(final IValueSerializer serializer) throws BufferOverflowException {
+		//super.serialize(serializer);
 		serializer.putLong(this.getTimestamp());
 		serializer.putString(this.getClassSignature());
 		serializer.putLong(this.getTraceId());
 		serializer.putInt(this.getOrderIndex());
 		serializer.putString(this.getCause());
 	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<?>[] getValueTypes() {
+		return TYPES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] getValueNames() {
+		return PROPERTY_NAMES; // NOPMD
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int getSize() {
+		return SIZE;
+	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @deprecated This record uses the {@link kieker.common.record.IMonitoringRecord.Factory} mechanism. Hence, this method is not implemented.
+	 */
+	@Override
+	@Deprecated
+	public void initFromArray(final Object[] values) {
+		throw new UnsupportedOperationException();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(final Object obj) {
+		if (obj == null) return false;
+		if (obj == this) return true;
+		if (obj.getClass() != this.getClass()) return false;
+		
+		final DatabaseFailedEvent castedRecord = (DatabaseFailedEvent) obj;
+		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp()) return false;
+		if (this.getTimestamp() != castedRecord.getTimestamp()) return false;
+		if (!this.getClassSignature().equals(castedRecord.getClassSignature())) return false;
+		if (this.getTraceId() != castedRecord.getTraceId()) return false;
+		if (this.getOrderIndex() != castedRecord.getOrderIndex()) return false;
+		if (!this.getCause().equals(castedRecord.getCause())) return false;
+		return true;
+	}
+	
+	public final long getTimestamp() {
+		return this.timestamp;
+	}
+	
+	
+	public final String getClassSignature() {
+		return this.classSignature;
+	}
+	
+	
+	public final long getTraceId() {
+		return this.traceId;
+	}
+	
+	public final void setTraceId(long traceId) {
+		this.traceId = traceId;
+	}
+	
+	public final int getOrderIndex() {
+		return this.orderIndex;
+	}
+	
+	
+	public final String getCause() {
+		return this.cause;
+	}
+	
 }

--- a/kieker-common/src-gen/kieker/common/record/database/DatabaseFailedEventFactory.java
+++ b/kieker-common/src-gen/kieker/common/record/database/DatabaseFailedEventFactory.java
@@ -1,4 +1,20 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.database;
+
 
 import kieker.common.record.factory.IRecordFactory;
 import kieker.common.record.io.IValueDeserializer;
@@ -9,18 +25,19 @@ import kieker.common.record.io.IValueDeserializer;
  * @since 1.14
  */
 public final class DatabaseFailedEventFactory implements IRecordFactory<DatabaseFailedEvent> {
-
+	
+	
 	@Override
-	public DatabaseFailedEvent create(IValueDeserializer deserializer) {
+	public DatabaseFailedEvent create(final IValueDeserializer deserializer) {
 		return new DatabaseFailedEvent(deserializer);
 	}
-
+	
 	@Override
 	@Deprecated
 	public DatabaseFailedEvent create(final Object[] values) {
 		return new DatabaseFailedEvent(values);
 	}
-
+	
 	public int getRecordSizeInBytes() {
 		return DatabaseFailedEvent.SIZE;
 	}

--- a/kieker-common/src-gen/kieker/common/record/flow/ICallObjectRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/ICallObjectRecord.java
@@ -22,8 +22,8 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface ICallObjectRecord extends ICallRecord, IObjectRecord {
-	public int getCallerObjectId() ;
+	public int getCallerObjectId();
 	
-	public int getCalleeObjectId() ;
+	public int getCalleeObjectId();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/ICallRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/ICallRecord.java
@@ -22,12 +22,12 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface ICallRecord extends IOperationRecord {
-	public String getCallerOperationSignature() ;
+	public String getCallerOperationSignature();
 	
-	public String getCallerClassSignature() ;
+	public String getCallerClassSignature();
 	
-	public String getCalleeOperationSignature() ;
+	public String getCalleeOperationSignature();
 	
-	public String getCalleeClassSignature() ;
+	public String getCalleeClassSignature();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IClassSignature.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IClassSignature.java
@@ -23,6 +23,6 @@ import kieker.common.record.IMonitoringRecord;
  * @since 1.10
  */
 public interface IClassSignature extends IMonitoringRecord {
-	public String getClassSignature() ;
+	public String getClassSignature();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IEventRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IEventRecord.java
@@ -22,6 +22,6 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface IEventRecord extends IFlowRecord {
-	public long getTimestamp() ;
+	public long getTimestamp();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IExceptionRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IExceptionRecord.java
@@ -22,6 +22,6 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface IExceptionRecord extends IFlowRecord {
-	public String getCause() ;
+	public String getCause();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IInterfaceRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IInterfaceRecord.java
@@ -22,6 +22,6 @@ package kieker.common.record.flow;
  * @since 1.10
  */
 public interface IInterfaceRecord extends IFlowRecord {
-	public String getInterface() ;
+	public String getInterface();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IObjectRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IObjectRecord.java
@@ -22,6 +22,6 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface IObjectRecord extends IFlowRecord, IClassSignature {
-	public int getObjectId() ;
+	public int getObjectId();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IOperationSignature.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IOperationSignature.java
@@ -23,6 +23,6 @@ import kieker.common.record.IMonitoringRecord;
  * @since 1.10
  */
 public interface IOperationSignature extends IMonitoringRecord {
-	public String getOperationSignature() ;
+	public String getOperationSignature();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/IThreadBasedRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/IThreadBasedRecord.java
@@ -22,8 +22,8 @@ package kieker.common.record.flow;
  * @since 1.13
  */
 public interface IThreadBasedRecord extends IFlowRecord {
-	public long getThreadId() ;
+	public long getThreadId();
 	
-	public int getOrderIndex() ;
+	public int getOrderIndex();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/ITraceRecord.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/ITraceRecord.java
@@ -22,8 +22,9 @@ package kieker.common.record.flow;
  * @since 1.6
  */
 public interface ITraceRecord extends IFlowRecord {
-	public long getTraceId() ;
+	public long getTraceId();
+	public void setTraceId(long traceId);
 	
-	public int getOrderIndex() ;
+	public int getOrderIndex();
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/trace/AbstractTraceEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/trace/AbstractTraceEvent.java
@@ -38,7 +38,7 @@ public abstract class AbstractTraceEvent extends AbstractEvent implements ITrace
 	
 		
 	/** property declarations. */
-	private final long traceId;
+	private long traceId;
 	private final int orderIndex;
 	
 	/**
@@ -119,6 +119,9 @@ public abstract class AbstractTraceEvent extends AbstractEvent implements ITrace
 		return this.traceId;
 	}
 	
+	public final void setTraceId(long traceId) {
+		this.traceId = traceId;
+	}
 	
 	public final int getOrderIndex() {
 		return this.orderIndex;

--- a/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeReceivedRemoteEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeReceivedRemoteEvent.java
@@ -1,8 +1,21 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.flow.trace;
 
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 import kieker.common.record.AbstractMonitoringRecord;
 import kieker.common.record.IMonitoringRecord;
@@ -13,7 +26,7 @@ import kieker.common.util.registry.IRegistry;
 
 /**
  * @author Felix Eichhorst
- * API compatibility: Kieker 1.10.0
+ * API compatibility: Kieker 1.13.0
  * 
  * @since 1.14
  */
@@ -121,27 +134,6 @@ public class BeforeReceivedRemoteEvent extends AbstractMonitoringRecord implemen
 		this.orderIndex = (Integer) values[4];
 	}
 
-	/**
-	 * This constructor converts the given buffer into a record.
-	 * 
-	 * @param buffer
-	 *            The bytes for the record
-	 * @param stringRegistry
-	 *            The string registry for deserialization
-	 * 
-	 * @throws BufferUnderflowException
-	 *             if buffer not sufficient
-	 *
-	 * @deprecated since 1.13. Use {@link #BeforeReceivedRemoteEvent(IValueDeserializer)} instead.
-	 */
-	@Deprecated
-	public BeforeReceivedRemoteEvent(final ByteBuffer buffer, final IRegistry<String> stringRegistry) throws BufferUnderflowException {
-		this.timestamp = buffer.getLong();
-		this.callerTraceId = buffer.getLong();
-		this.callerOrderIndex = buffer.getInt();
-		this.traceId = buffer.getLong();
-		this.orderIndex = buffer.getInt();
-	}
 	
 	/**
 	 * @param deserializer
@@ -154,7 +146,6 @@ public class BeforeReceivedRemoteEvent extends AbstractMonitoringRecord implemen
 		this.traceId = deserializer.getLong();
 		this.orderIndex = deserializer.getInt();
 	}
-	
 	
 	/**
 	 * {@inheritDoc}
@@ -177,6 +168,18 @@ public class BeforeReceivedRemoteEvent extends AbstractMonitoringRecord implemen
 	 */
 	@Override
 	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void serialize(final IValueSerializer serializer) throws BufferOverflowException {
+		//super.serialize(serializer);
+		serializer.putLong(this.getTimestamp());
+		serializer.putLong(this.getCallerTraceId());
+		serializer.putInt(this.getCallerOrderIndex());
+		serializer.putLong(this.getTraceId());
+		serializer.putInt(this.getOrderIndex());
 	}
 	/**
 	 * {@inheritDoc}
@@ -254,15 +257,6 @@ public class BeforeReceivedRemoteEvent extends AbstractMonitoringRecord implemen
 	
 	public final int getOrderIndex() {
 		return this.orderIndex;
-	}
-
-	@Override
-	public void serialize(IValueSerializer serializer) throws BufferOverflowException {
-		serializer.putLong(this.getTimestamp());
-		serializer.putLong(this.getCallerTraceId());
-		serializer.putInt(this.getCallerOrderIndex());
-		serializer.putLong(this.getTraceId());
-		serializer.putInt(this.getOrderIndex());
 	}
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeReceivedRemoteEventFactory.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeReceivedRemoteEventFactory.java
@@ -1,4 +1,20 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.flow.trace;
+
 
 import kieker.common.record.factory.IRecordFactory;
 import kieker.common.record.io.IValueDeserializer;
@@ -9,6 +25,7 @@ import kieker.common.record.io.IValueDeserializer;
  * @since 1.14
  */
 public final class BeforeReceivedRemoteEventFactory implements IRecordFactory<BeforeReceivedRemoteEvent> {
+	
 	
 	@Override
 	public BeforeReceivedRemoteEvent create(final IValueDeserializer deserializer) {

--- a/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeSentRemoteEvent.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeSentRemoteEvent.java
@@ -1,8 +1,21 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.flow.trace;
 
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 import kieker.common.record.AbstractMonitoringRecord;
 import kieker.common.record.IMonitoringRecord;
@@ -13,7 +26,7 @@ import kieker.common.util.registry.IRegistry;
 
 /**
  * @author Felix Eichhorst
- * API compatibility: Kieker 1.10.0
+ * API compatibility: Kieker 1.13.0
  * 
  * @since 1.14
  */
@@ -111,26 +124,6 @@ public class BeforeSentRemoteEvent extends AbstractMonitoringRecord implements I
 		this.technology = (String) values[3];
 	}
 
-	/**
-	 * This constructor converts the given buffer into a record.
-	 * 
-	 * @param buffer
-	 *            The bytes for the record
-	 * @param stringRegistry
-	 *            The string registry for deserialization
-	 * 
-	 * @throws BufferUnderflowException
-	 *             if buffer not sufficient
-	 *
-	 * @deprecated since 1.13. Use {@link #BeforeSentRemoteEvent(IValueDeserializer)} instead.
-	 */
-	@Deprecated
-	public BeforeSentRemoteEvent(final ByteBuffer buffer, final IRegistry<String> stringRegistry) throws BufferUnderflowException {
-		this.timestamp = buffer.getLong();
-		this.traceId = buffer.getLong();
-		this.orderIndex = buffer.getInt();
-		this.technology = stringRegistry.get(buffer.getInt());
-	}
 	
 	/**
 	 * @param deserializer
@@ -164,6 +157,17 @@ public class BeforeSentRemoteEvent extends AbstractMonitoringRecord implements I
 	@Override
 	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
 		stringRegistry.get(this.getTechnology());
+	}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void serialize(final IValueSerializer serializer) throws BufferOverflowException {
+		//super.serialize(serializer);
+		serializer.putLong(this.getTimestamp());
+		serializer.putLong(this.getTraceId());
+		serializer.putInt(this.getOrderIndex());
+		serializer.putString(this.getTechnology());
 	}
 	/**
 	 * {@inheritDoc}
@@ -235,14 +239,6 @@ public class BeforeSentRemoteEvent extends AbstractMonitoringRecord implements I
 	
 	public final String getTechnology() {
 		return this.technology;
-	}
-
-	@Override
-	public void serialize(IValueSerializer serializer) throws BufferOverflowException {
-		serializer.putLong(this.getTimestamp());
-		serializer.putLong(this.getTraceId());
-		serializer.putInt(this.getOrderIndex());
-		serializer.putString(this.getTechnology());
 	}
 	
 }

--- a/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeSentRemoteEventFactory.java
+++ b/kieker-common/src-gen/kieker/common/record/flow/trace/BeforeSentRemoteEventFactory.java
@@ -1,4 +1,20 @@
+/***************************************************************************
+ * Copyright 2017 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
 package kieker.common.record.flow.trace;
+
 
 import kieker.common.record.factory.IRecordFactory;
 import kieker.common.record.io.IValueDeserializer;
@@ -9,6 +25,7 @@ import kieker.common.record.io.IValueDeserializer;
  * @since 1.14
  */
 public final class BeforeSentRemoteEventFactory implements IRecordFactory<BeforeSentRemoteEvent> {
+	
 	
 	@Override
 	public BeforeSentRemoteEvent create(final IValueDeserializer deserializer) {

--- a/kieker-common/src-gen/kieker/common/record/misc/HostApplicationMetaData.java
+++ b/kieker-common/src-gen/kieker/common/record/misc/HostApplicationMetaData.java
@@ -31,19 +31,19 @@ import kieker.common.util.registry.IRegistry;
  * @since 1.13
  */
 public class HostApplicationMetaData extends AbstractMonitoringRecord implements IMonitoringRecord.Factory, IMonitoringRecord.BinaryFactory {
-	private static final long serialVersionUID = 5425789809172379297L;
+	private static final long serialVersionUID = 7989655300501494980L;
 
 	/** Descriptive definition of the serialization size of the record. */
 	public static final int SIZE = TYPE_SIZE_STRING // HostApplicationMetaData.systemName
 			 + TYPE_SIZE_STRING // HostApplicationMetaData.ipAddress
-			 + TYPE_SIZE_STRING // HostApplicationMetaData.hostname
+			 + TYPE_SIZE_STRING // HostApplicationMetaData.hostName
 			 + TYPE_SIZE_STRING // HostApplicationMetaData.applicationName
 	;
 	
 	public static final Class<?>[] TYPES = {
 		String.class, // HostApplicationMetaData.systemName
 		String.class, // HostApplicationMetaData.ipAddress
-		String.class, // HostApplicationMetaData.hostname
+		String.class, // HostApplicationMetaData.hostName
 		String.class, // HostApplicationMetaData.applicationName
 	};
 	
@@ -51,21 +51,21 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 	/** default constants. */
 	public static final String SYSTEM_NAME = "";
 	public static final String IP_ADDRESS = "";
-	public static final String HOSTNAME = "";
+	public static final String HOST_NAME = "";
 	public static final String APPLICATION_NAME = "";
 	
 	/** property name array. */
 	private static final String[] PROPERTY_NAMES = {
 		"systemName",
 		"ipAddress",
-		"hostname",
+		"hostName",
 		"applicationName",
 	};
 	
 	/** property declarations. */
 	private final String systemName;
 	private final String ipAddress;
-	private final String hostname;
+	private final String hostName;
 	private final String applicationName;
 	
 	/**
@@ -75,15 +75,15 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 	 *            systemName
 	 * @param ipAddress
 	 *            ipAddress
-	 * @param hostname
-	 *            hostname
+	 * @param hostName
+	 *            hostName
 	 * @param applicationName
 	 *            applicationName
 	 */
-	public HostApplicationMetaData(final String systemName, final String ipAddress, final String hostname, final String applicationName) {
+	public HostApplicationMetaData(final String systemName, final String ipAddress, final String hostName, final String applicationName) {
 		this.systemName = systemName == null?"":systemName;
 		this.ipAddress = ipAddress == null?"":ipAddress;
-		this.hostname = hostname == null?"":hostname;
+		this.hostName = hostName == null?"":hostName;
 		this.applicationName = applicationName == null?"":applicationName;
 	}
 
@@ -101,7 +101,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 		AbstractMonitoringRecord.checkArray(values, TYPES);
 		this.systemName = (String) values[0];
 		this.ipAddress = (String) values[1];
-		this.hostname = (String) values[2];
+		this.hostName = (String) values[2];
 		this.applicationName = (String) values[3];
 	}
 
@@ -120,7 +120,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 		AbstractMonitoringRecord.checkArray(values, valueTypes);
 		this.systemName = (String) values[0];
 		this.ipAddress = (String) values[1];
-		this.hostname = (String) values[2];
+		this.hostName = (String) values[2];
 		this.applicationName = (String) values[3];
 	}
 
@@ -132,7 +132,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 	public HostApplicationMetaData(final IValueDeserializer deserializer) {
 		this.systemName = deserializer.getString();
 		this.ipAddress = deserializer.getString();
-		this.hostname = deserializer.getString();
+		this.hostName = deserializer.getString();
 		this.applicationName = deserializer.getString();
 	}
 	
@@ -147,7 +147,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 		return new Object[] {
 			this.getSystemName(),
 			this.getIpAddress(),
-			this.getHostname(),
+			this.getHostName(),
 			this.getApplicationName()
 		};
 	}
@@ -158,7 +158,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 	public void registerStrings(final IRegistry<String> stringRegistry) {	// NOPMD (generated code)
 		stringRegistry.get(this.getSystemName());
 		stringRegistry.get(this.getIpAddress());
-		stringRegistry.get(this.getHostname());
+		stringRegistry.get(this.getHostName());
 		stringRegistry.get(this.getApplicationName());
 	}
 	/**
@@ -169,7 +169,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 		//super.serialize(serializer);
 		serializer.putString(this.getSystemName());
 		serializer.putString(this.getIpAddress());
-		serializer.putString(this.getHostname());
+		serializer.putString(this.getHostName());
 		serializer.putString(this.getApplicationName());
 	}
 	/**
@@ -220,7 +220,7 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 		if (this.getLoggingTimestamp() != castedRecord.getLoggingTimestamp()) return false;
 		if (!this.getSystemName().equals(castedRecord.getSystemName())) return false;
 		if (!this.getIpAddress().equals(castedRecord.getIpAddress())) return false;
-		if (!this.getHostname().equals(castedRecord.getHostname())) return false;
+		if (!this.getHostName().equals(castedRecord.getHostName())) return false;
 		if (!this.getApplicationName().equals(castedRecord.getApplicationName())) return false;
 		return true;
 	}
@@ -235,8 +235,8 @@ public class HostApplicationMetaData extends AbstractMonitoringRecord implements
 	}
 	
 	
-	public final String getHostname() {
-		return this.hostname;
+	public final String getHostName() {
+		return this.hostName;
 	}
 	
 	

--- a/kieker-monitoring/src/kieker/monitoring/writer/explorviz/ExplorVizTcpWriter.java
+++ b/kieker-monitoring/src/kieker/monitoring/writer/explorviz/ExplorVizTcpWriter.java
@@ -190,13 +190,13 @@ public class ExplorVizTcpWriter extends AbstractMonitoringWriter implements IReg
 			final HostApplicationMetaData record = (HostApplicationMetaData) kiekerRecord;
 			this.writerRegistry.register(record.getSystemName());
 			this.writerRegistry.register(record.getIpAddress());
-			this.writerRegistry.register(record.getHostname());
+			this.writerRegistry.register(record.getHostName());
 			this.writerRegistry.register(record.getApplicationName());
 
 			buffer.put(HOST_APPLICATION_META_DATA_CLAZZ_ID);
 			buffer.putInt(this.writerRegistry.getId(record.getSystemName()));
 			buffer.putInt(this.writerRegistry.getId(record.getIpAddress()));
-			buffer.putInt(this.writerRegistry.getId(record.getHostname()));
+			buffer.putInt(this.writerRegistry.getId(record.getHostName()));
 			buffer.putInt(this.writerRegistry.getId(record.getApplicationName()));
 		}
 	}


### PR DESCRIPTION
A minor fix in the TemplateGenerator which produces in Java interfaces made it necessary to regenerated some interfaces. The generator fix was necessary, as the new changeable fields feature was only supported by the EventGenerator which can cause issues when implementing record rewriting stages.