### PR TITLE
KIEKER 1740: Added properties for username and password for the JMSWr…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ libJctoolsVersion = 1.2.1
 # Thresholds are now project-specific.
 # Please have a look at the subproject's file 'gradle.properties'.
 
-cpdErrorThreshold = 457
+cpdErrorThreshold = 453
 
 org.gradle.jvmargs = "-XX:MaxPermSize=128m"
 

--- a/kieker-analysis/gradle.properties
+++ b/kieker-analysis/gradle.properties
@@ -5,4 +5,4 @@ findbugsErrorThreshold = 0
 findbugsWarningThreshold = 0
 
 pmdErrorThreshold = 203
-pmdWarningThreshold = 92
+pmdWarningThreshold = 90

--- a/kieker-monitoring/gradle.properties
+++ b/kieker-monitoring/gradle.properties
@@ -4,5 +4,5 @@ checkstyleWarningThreshold = 6
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 1
 
-pmdErrorThreshold = 221
+pmdErrorThreshold = 213
 pmdWarningThreshold = 68

--- a/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
+++ b/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
@@ -208,6 +208,13 @@ kieker.monitoring.writer.jms.JmsWriter.FactoryLookupName=ConnectionFactory
 ## it is automatically deleted.
 kieker.monitoring.writer.jms.JmsWriter.MessageTimeToLive=10000
 
+## The username needed for authentication
+## Leave empty for no credentials
+kieker.monitoring.writer.jms.JmsWriter.Username=
+
+## The password needed for authentication
+## Leave empty for no credentials
+kieker.monitoring.writer.jms.JmsWriter.Password=
 
 #####
 #kieker.monitoring.writer=kieker.monitoring.writer.jmx.JmxWriter

--- a/kieker-monitoring/src/kieker/monitoring/writer/jms/JmsWriter.java
+++ b/kieker-monitoring/src/kieker/monitoring/writer/jms/JmsWriter.java
@@ -101,7 +101,7 @@ public class JmsWriter extends AbstractMonitoringWriter {
 			final ConnectionFactory factory = (ConnectionFactory) context.lookup(this.configFactoryLookupName);
 
 
-			if(this.configUsername.isEmpty() && this.configPassword.isEmpty()) {
+			if (this.configUsername.isEmpty() && this.configPassword.isEmpty()) {
                 this.connection = factory.createConnection();
             } else {
                 this.connection = factory.createConnection(this.configUsername, this.configPassword);

--- a/kieker-monitoring/src/kieker/monitoring/writer/jms/JmsWriter.java
+++ b/kieker-monitoring/src/kieker/monitoring/writer/jms/JmsWriter.java
@@ -54,12 +54,16 @@ public class JmsWriter extends AbstractMonitoringWriter {
 	public static final String CONFIG_CONTEXTFACTORYTYPE = PREFIX + "ContextFactoryType"; // NOCS (afterPREFIX)
 	public static final String CONFIG_FACTORYLOOKUPNAME = PREFIX + "FactoryLookupName"; // NOCS (afterPREFIX)
 	public static final String CONFIG_MESSAGETTL = PREFIX + "MessageTimeToLive"; // NOCS (afterPREFIX)
+    public static final String CONFIG_USERNAME = PREFIX + "Username"; // NOCS (afterPREFIX)
+    public static final String CONFIG_PASSWORD = PREFIX + "Password"; // NOCS (afterPREFIX)
 
 	private final String configContextFactoryType;
 	private final String configProviderUrl;
 	private final String configFactoryLookupName;
 	private final String configTopic;
 	private final long configMessageTimeToLive;
+	private final String configUsername;
+	private final String configPassword;
 
 	private Session session;
 	private Connection connection;
@@ -72,6 +76,8 @@ public class JmsWriter extends AbstractMonitoringWriter {
 		this.configFactoryLookupName = configuration.getStringProperty(CONFIG_FACTORYLOOKUPNAME);
 		this.configTopic = configuration.getStringProperty(CONFIG_TOPIC);
 		this.configMessageTimeToLive = configuration.getLongProperty(CONFIG_MESSAGETTL);
+		this.configUsername = configuration.getStringProperty(CONFIG_USERNAME);
+		this.configPassword = configuration.getStringProperty(CONFIG_PASSWORD);
 
 		this.init();
 	}
@@ -93,7 +99,14 @@ public class JmsWriter extends AbstractMonitoringWriter {
 			// context.addToEnvironment(Context.PROVIDER_URL, providerUrl);
 
 			final ConnectionFactory factory = (ConnectionFactory) context.lookup(this.configFactoryLookupName);
-			this.connection = factory.createConnection();
+
+
+			if(this.configUsername.isEmpty() && this.configPassword.isEmpty()) {
+                this.connection = factory.createConnection();
+            } else {
+                this.connection = factory.createConnection(this.configUsername, this.configPassword);
+            }
+
 			this.session = this.connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 			this.connection.start();
 

--- a/kieker-tools/gradle.properties
+++ b/kieker-tools/gradle.properties
@@ -5,4 +5,4 @@ findbugsErrorThreshold = 0
 findbugsWarningThreshold = 0
 
 pmdErrorThreshold = 240
-pmdWarningThreshold = 93
+pmdWarningThreshold = 89


### PR DESCRIPTION
…iter and the usage in case the properties are set.

Especially in distributed setups or Docker-based setups, a JMS server might require authentication with username and password. This PR allows to provide username and password for JMS in the configuration file. In case no credentials are provided, it is assumed that none are needed and behaves as before.