### PR TITLE
KIEKER-1548: Fixed wrongly named label for agent.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
 
     stage('Push to Stable') {
       agent {
-        label 'kieker-docker-slave'
+        label 'kieker-slave-docker'
       }
       when {
         beforeAgent true


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Fixed wrong agent label name in "push to stable" stage.

## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
