### PR TITLE
KIEKER-1779: Remove custom insertion of user IDs for docker execution.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
 
   environment {
-    DOCKER_ARGS = '--rm -u `id -u`'
+    DOCKER_ARGS = '--rm'
   }
 
   agent none

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
 
   environment {
-    DOCKER_ARGS = '--rm'
+    DOCKER_ARGS = ''
   }
 
   agent none


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Removed insertion of user ID to the 'docker run' command as Jenkins seems to do it now.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
