### PR TITLE
KIEKER-1782: Set retry parameter to 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
   options {
     buildDiscarder logRotator(artifactNumToKeepStr: '10')
     timeout(time: 1, unit: 'HOURS')
-    retry(1)
+    retry(2)
     parallelsAlwaysFailFast()
   }
 


### PR DESCRIPTION
.. to check whether the parameter stands for total number of tries instead of number of retries.

# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Add one retry of the build in case the initial try fails.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
