### PR TITLE
Kieker 1787 disable chw test inheritance rule

### DIFF
--- a/config/pmdrules.xml
+++ b/config/pmdrules.xml
@@ -79,6 +79,7 @@
 		<exclude name="DisallowRawTypeDeclaration" />
 		<exclude name="MissingPluralVariableName"/>
 		<exclude name="MissingUnitSuffix"/>
+    <exclude name="UnitTestMayNotExtendAnything"/>
 	</rule>
 
 	<!-- <rule ref="rulesets/java/logging-jakarta-commons.xml/GuardLogStatement"> -->

--- a/kieker-common/gradle.properties
+++ b/kieker-common/gradle.properties
@@ -4,5 +4,5 @@ checkstyleWarningThreshold = 1
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 4
 
-pmdErrorThreshold = 33
+pmdErrorThreshold = 0
 pmdWarningThreshold = 25

--- a/kieker-monitoring/gradle.properties
+++ b/kieker-monitoring/gradle.properties
@@ -4,5 +4,5 @@ checkstyleWarningThreshold = 5
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 1
 
-pmdErrorThreshold = 16
+pmdErrorThreshold = 0
 pmdWarningThreshold = 85

--- a/kieker-tools/gradle.properties
+++ b/kieker-tools/gradle.properties
@@ -4,6 +4,6 @@ checkstyleWarningThreshold = 1
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 3
 
-pmdErrorThreshold = 13
+pmdErrorThreshold = 0
 pmdWarningThreshold = 41
 

--- a/kieker-tools/kdb/gradle.properties
+++ b/kieker-tools/kdb/gradle.properties
@@ -4,6 +4,6 @@ checkstyleWarningThreshold = 1
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 2
 
-pmdErrorThreshold = 6
+pmdErrorThreshold = 0
 pmdWarningThreshold = 22
 

--- a/kieker-tools/log-replayer/gradle.properties
+++ b/kieker-tools/log-replayer/gradle.properties
@@ -4,6 +4,6 @@ checkstyleWarningThreshold = 0
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 0
 
-pmdErrorThreshold = 3
+pmdErrorThreshold = 0
 pmdWarningThreshold = 4
 

--- a/kieker-tools/opad/gradle.properties
+++ b/kieker-tools/opad/gradle.properties
@@ -4,6 +4,6 @@ checkstyleWarningThreshold = 0
 findbugsErrorThreshold = 0
 findbugsWarningThreshold = 2
 
-pmdErrorThreshold = 15
+pmdErrorThreshold = 0
 pmdWarningThreshold = 6
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Disabled chw's custom PMD rule " UnitTestMayNotExtendAnything"
- Reduced thresholds (i.e. set PMD error counters to 0)


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds

