### PR TITLE
Allow Adaptive Monitoring for Constructor

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -135,6 +135,9 @@ public final class PatternParser {
 
 	private static final String parseMethodName(final String methodName) throws InvalidPatternException {
 		try {
+			if ("<init>".equals(methodName)) {
+				return "<init>";
+			}
 			return PatternParser.parseIdentifier(methodName);
 		} catch (final InvalidPatternException ex) {
 			throw new InvalidPatternException("Invalid method name.", ex);

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -235,9 +235,9 @@ public class TestPatternParser extends AbstractKiekerTest {
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {
-		final String constructorPattern = "new ..*.*(..)"; // should match all constructors and nothing else
+		final String constructorPattern = "new ..*.<init>(..)"; // should match all constructors and nothing else
 
-		final String constructorSignature = "public package.Class.constructor()";
+		final String constructorSignature = "public package.Class.<init>()";
 		final String methodSignature = "public void package.Class.method()";
 
 		final Matcher constructorMatcher = PatternParser.parseToPattern(constructorPattern).matcher("");
@@ -250,7 +250,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 				.addNativeNonNativeVariant("").addNativeNonNativeVariant("native")
 				.addreturnTypeVariant("")
 				.addfqClassNameVariant("package.Class").addfqClassNameVariant("").addfqClassNameVariant("Class")
-				.addoperationNameVariant("constructor").addoperationNameVariant("hierGehtAlles")
+				.addoperationNameVariant("<init>")
 				.addparameterListVariant("").addparameterListVariant("int").addparameterListVariant("int, Class");
 		final List<String> positiveSignatureList = positiveSignature.getSignatures();
 		for (final String signature : positiveSignatureList) {


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Bugfix: <init> was not allowed as methodName for PatternParser, therefore adaptive monitoring was not able to include/exclude constructors directly. This works now.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
