### PR TITLE
Fix wrong writer name, monitor every method including getters/setters…

### DIFF
--- a/kieker-examples/monitoring/adaptive-monitoring/build.gradle
+++ b/kieker-examples/monitoring/adaptive-monitoring/build.gradle
@@ -24,7 +24,7 @@ jar {
 task runMonitoring(type: JavaExec) {
 	main = mainClassName
 	classpath = sourceSets.main.runtimeClasspath
-	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.AsciiFileWriter.customStoragePath=monitoring-logs',
+	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
 	           "-javaagent:lib/kieker-1.14-SNAPSHOT-aspectj.jar",
 			   '-Dorg.aspectj.weaver.showWeaveInfo=true',
 			   '-Daj.weaving.verbose=true',

--- a/kieker-examples/monitoring/adaptive-monitoring/config/kieker.adaptiveMonitoring.conf
+++ b/kieker-examples/monitoring/adaptive-monitoring/config/kieker.adaptiveMonitoring.conf
@@ -1,3 +1,9 @@
 # Comment or uncomment the following line to enable/disable monitoring for the example
-
 #- *
+
+# Comment or uncomment the following line to enable/disable monitoring only for Bookstore.searchBook()
+#- public void kieker.examples.monitoring.adaptive.Bookstore.searchBook()
+
+# Comment or uncomment the following two lines enable/disable monitoring for all but Bookstore.searchBook()
+#- *
+#+ public void kieker.examples.monitoring.adaptive.Bookstore.searchBook()

--- a/kieker-examples/monitoring/adaptive-monitoring/src/main/resources/META-INF/aop.example.xml
+++ b/kieker-examples/monitoring/adaptive-monitoring/src/main/resources/META-INF/aop.example.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE aspectj PUBLIC "-//AspectJ//DTD//EN" "http://www.aspectj.org/dtd/aspectj_1_5_0.dtd">
+
+<aspectj>
+	<weaver options=""> <!-- options="-verbose -showWeaveInfo -Xjoinpoints:synchronization" -->
+		<include within="*"/>
+		<exclude within="org.apache.commons.logging..*" /> 
+		<exclude within="org.slf4j..*" /> 
+		<exclude within="java.util.logging..*" /> 
+		<exclude within="org.apache.log4j..*" />
+		<!-- excludes the queue implementation used internally by Kieker's monitoring component -->
+		<exclude within="org.jctools..*" />
+	</weaver>
+
+	<aspects>
+		<!-- monitor everything, including getters and setters -->
+		<aspect name="kieker.monitoring.probe.aspectj.flow.operationExecution.FullInstrumentation" />
+	</aspects>
+</aspectj>


### PR DESCRIPTION
… and add examples for adaptive monitoring

# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Fix wrong writer name in build.gradle - else, files will be written to /tmp/ instead of monitoring-logs
- Monitor every method including getters and setters in example by adding aop.xml and add examples lines for adaptive monitoring 


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
