### PR TITLE
Check constructor name for adaptive monitoring

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -103,7 +103,10 @@ public final class PatternParser {
 			}
 			final String fqClassName = fqName.substring(0, index);
 			final String methodName = fqName.substring(index + 1);
-
+			if ("new".equals(tokens[numOfModifiers]) && !"<init>".equals(methodName)) {
+				throw new InvalidPatternException("Invalid constructor name - must always be <init>");
+			}
+			
 			final String params = trimPattern.substring(openingParenthesis + 1, closingParenthesis).trim();
 			final String throwsPattern;
 			final int throwsPatternStart = closingParenthesis + 1;

--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -135,6 +135,9 @@ public final class PatternParser {
 
 	private static final String parseMethodName(final String methodName) throws InvalidPatternException {
 		try {
+			if ("<init>".equals(methodName)) {
+				return "<init>";
+			}
 			return PatternParser.parseIdentifier(methodName);
 		} catch (final InvalidPatternException ex) {
 			throw new InvalidPatternException("Invalid method name.", ex);

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -235,9 +235,9 @@ public class TestPatternParser extends AbstractKiekerTest {
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {
-		final String constructorPattern = "new ..*.*(..)"; // should match all constructors and nothing else
+		final String constructorPattern = "new ..*.<init>(..)"; // should match all constructors and nothing else
 
-		final String constructorSignature = "public package.Class.constructor()";
+		final String constructorSignature = "public package.Class.<init>()";
 		final String methodSignature = "public void package.Class.method()";
 
 		final Matcher constructorMatcher = PatternParser.parseToPattern(constructorPattern).matcher("");
@@ -250,7 +250,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 				.addNativeNonNativeVariant("").addNativeNonNativeVariant("native")
 				.addreturnTypeVariant("")
 				.addfqClassNameVariant("package.Class").addfqClassNameVariant("").addfqClassNameVariant("Class")
-				.addoperationNameVariant("constructor").addoperationNameVariant("hierGehtAlles")
+				.addoperationNameVariant("<init>")
 				.addparameterListVariant("").addparameterListVariant("int").addparameterListVariant("int, Class");
 		final List<String> positiveSignatureList = positiveSignature.getSignatures();
 		for (final String signature : positiveSignatureList) {

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -138,7 +138,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 		final String[] visibilities = { "public", "private", "package", "protected", "" };
 		final String[] staticNonStatics = { "static", "non_static", "" };
 		final String[] nativeNonNatives = { "native", "non_native", "" };
-		final String[] returnTypesOrNews = { "java.lang.String", "new", "*", "..*" };
+		final String[] returnTypes = { "java.lang.String", "*", "..*" };
 		final String[] fqClassNames = { "a.b.C", "a.b.*", "*", "..*" };
 		final String[] operationNames = { "doIt", "get*", "*" };
 		final String[] paramLists = { "", "*", "A, B", ".." };
@@ -161,7 +161,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 		final boolean[] visibilityMatches = { true, false, false, false, true };
 		final boolean[] staticNonStaticMatches = { true, false, true };
 		final boolean[] nativeNonNativeMatches = { true, false, true };
-		final boolean[] returnTypeOrNewMatches = { false, false, true, true };
+		final boolean[] returnTypeMatches = { false, true, true };
 		final boolean[] fqClassNameMatches = { false, false, false, true };
 		final boolean[] operationNameMatches = { false, false, true };
 		final boolean[] paramListMatches = { true, false, false, true };
@@ -179,7 +179,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 		for (int visibilityIdy = 0; visibilityIdy < visibilities.length; visibilityIdy++) {
 			for (int staticNonStaticIdx = 0; staticNonStaticIdx < staticNonStatics.length; staticNonStaticIdx++) { // NOCS
 				for (int nativeNonNativeIdx = 0; nativeNonNativeIdx < nativeNonNatives.length; nativeNonNativeIdx++) { // NOCS
-					for (int returnTypeOrNewIdx = 0; returnTypeOrNewIdx < returnTypesOrNews.length; returnTypeOrNewIdx++) { // NOCS
+					for (int returnTypeOrNewIdx = 0; returnTypeOrNewIdx < returnTypes.length; returnTypeOrNewIdx++) { // NOCS
 						for (int fqClassNameIdx = 0; fqClassNameIdx < fqClassNames.length; fqClassNameIdx++) { // NOCS
 							for (int operationNameIdx = 0; operationNameIdx < operationNames.length; operationNameIdx++) { // NOCS
 								for (int paramListIdx = 0; paramListIdx < paramLists.length; paramListIdx++) { // NOCS
@@ -196,7 +196,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 											if (nativeNonNatives[nativeNonNativeIdx].length() > 0) {
 												signatureBuilder.append(nativeNonNatives[nativeNonNativeIdx]).append(white);
 											}
-											signatureBuilder.append(returnTypesOrNews[returnTypeOrNewIdx]).append(white).append(fqClassNames[fqClassNameIdx])
+											signatureBuilder.append(returnTypes[returnTypeOrNewIdx]).append(white).append(fqClassNames[fqClassNameIdx])
 													.append('.').append(operationNames[operationNameIdx]).append(whiteOrEmpty).append('(').append(whiteOrEmpty);
 
 											if (paramLists[paramListIdx].length() > 0) {
@@ -209,13 +209,13 @@ public class TestPatternParser extends AbstractKiekerTest {
 											final boolean expected = visibilityMatches[visibilityIdy]
 													&& staticNonStaticMatches[staticNonStaticIdx]
 													&& nativeNonNativeMatches[nativeNonNativeIdx]
-													&& returnTypeOrNewMatches[returnTypeOrNewIdx]
+													&& returnTypeMatches[returnTypeOrNewIdx]
 													&& fqClassNameMatches[fqClassNameIdx]
 													&& operationNameMatches[operationNameIdx]
 													&& paramListMatches[paramListIdx];
 
 											this.checkCombination(signature, visibilities[visibilityIdy], staticNonStatics[staticNonStaticIdx],
-													nativeNonNatives[nativeNonNativeIdx], returnTypesOrNews[returnTypeOrNewIdx], fqClassNames[fqClassNameIdx],
+													nativeNonNatives[nativeNonNativeIdx], returnTypes[returnTypeOrNewIdx], fqClassNames[fqClassNameIdx],
 													operationNames[operationNameIdx], paramLists[paramListIdx]);
 
 											final Pattern pattern = PatternParser.parseToPattern(signature);


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- While new package.Class() will not match any signature, it is currently allowed. new package.Class<init>() would possibly match signatures. This PR adds a check that new is always used together with <init>.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
