### PR TITLE
Fix error: Parsing of Array-return-types was not possible

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -227,6 +227,17 @@ public final class PatternParser {
 			}
 		}
 	}
+	
+	private static final String parseType(final String type) throws InvalidPatternException {
+		final int index = type.indexOf('[');
+		if (index != -1) {
+			final String onlyIdentified = type.substring(0, index);
+			final String onlyArrayParenthesis = type.substring(index).replace("[", "\\[").replace("]", "\\]");
+			return PatternParser.parseIdentifier(onlyIdentified) + onlyArrayParenthesis;
+		} else {
+			return PatternParser.parseIdentifier(type);
+		}
+	}
 
 	private static final String parseIdentifier(final String identifier) throws InvalidPatternException {
 		final char[] array = identifier.toCharArray();
@@ -257,7 +268,7 @@ public final class PatternParser {
 		final String[] tokens = fqClassname.split("\\.");
 		if (tokens.length == 1) {
 			try {
-				return PatternParser.parseIdentifier(fqClassname);
+				return PatternParser.parseType(fqClassname);
 			} catch (final InvalidPatternException ex) {
 				throw new InvalidPatternException("Invalid fully qualified type.", ex);
 			}
@@ -284,7 +295,7 @@ public final class PatternParser {
 				sb.append("(([\\p{javaJavaIdentifierPart}\\.])*\\.)?");
 			} else {
 				try {
-					sb.append(PatternParser.parseIdentifier(tokens[i]));
+					sb.append(PatternParser.parseType(tokens[i]));
 				} catch (final InvalidPatternException ex) {
 					throw new InvalidPatternException("Invalid fully qualified type.", ex);
 				}
@@ -292,7 +303,7 @@ public final class PatternParser {
 			}
 		}
 		try {
-			sb.append(PatternParser.parseIdentifier(tokens[length - 1]));
+			sb.append(PatternParser.parseType(tokens[length - 1]));
 		} catch (final InvalidPatternException ex) {
 			final InvalidPatternException newEx = new InvalidPatternException("Invalid fully qualified type.");
 			throw (InvalidPatternException) newEx.initCause(ex);
@@ -305,14 +316,7 @@ public final class PatternParser {
 			return "";
 		} else {
 			try {
-				final int index = retType.indexOf('[');
-            			if (index != -1) {
-               				final String onlyIdentified = retType.substring(0, index);
-               				final String onlyArrayParenthesis = retType.substring(index).replace("[", "\\[").replace("]", "\\]");
-               				return PatternParser.parseFQClassname(onlyIdentified) + onlyArrayParenthesis + "\\s";
-            			} else {
-  					return PatternParser.parseFQClassname(retType) + "\\s";
-				}
+  				return PatternParser.parseFQClassname(retType) + "\\s";
 			} catch (final InvalidPatternException ex) {
 				throw new InvalidPatternException("Invalid return type.", ex);
 			}

--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -101,7 +101,7 @@ public final class PatternParser {
 			if ((index == -1) || (index == (fqName.length() - 1))) {
 				throw new InvalidPatternException("Invalid fully qualified type or method name.");
 			}
-			final String fqClassName = fqName.substring(0, index);
+			final String fqClassName = fqName.substring(0, index); // NOPMD declaring variable in this context is usefull
 			final String methodName = fqName.substring(index + 1);
 			if ("new".equals(tokens[numOfModifiers]) && !"<init>".equals(methodName)) {
 				throw new InvalidPatternException("Invalid constructor name - must always be <init>");

--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -305,7 +305,14 @@ public final class PatternParser {
 			return "";
 		} else {
 			try {
-				return PatternParser.parseFQClassname(retType) + "\\s";
+				final int index = retType.indexOf('[');
+            			if (index != -1) {
+               				final String onlyIdentified = retType.substring(0, index);
+               				final String onlyArrayParenthesis = retType.substring(index).replace("[", "\\[").replace("]", "\\]");
+               				return PatternParser.parseFQClassname(onlyIdentified) + onlyArrayParenthesis + "\\s";
+            			} else {
+  					return PatternParser.parseFQClassname(retType) + "\\s";
+				}
 			} catch (final InvalidPatternException ex) {
 				throw new InvalidPatternException("Invalid return type.", ex);
 			}

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -232,6 +232,21 @@ public class TestPatternParser extends AbstractKiekerTest {
 			}
 		}
 	}
+	
+	@Test
+   public void testByteReturn() throws InvalidPatternException {
+      final String signatureByte = "public byte package.Class.method()";
+      final Pattern patternByte = PatternParser.parseToPattern("public byte package.Class.method()");
+      Assert.assertTrue(patternByte.matcher(signatureByte).matches());
+      
+      final String signatureArray = "public byte[] package.Class.method()";
+      final Pattern patternArray = PatternParser.parseToPattern("public byte[] package.Class.method()");
+      Assert.assertTrue(patternArray.matcher(signatureArray).matches());
+      
+      final String signatureDoubleArray = "public byte[][] package.Class.method()";
+      final Pattern patternDoubleArray = PatternParser.parseToPattern("public byte[][] package.Class.method()");
+      Assert.assertTrue(patternDoubleArray.matcher(signatureDoubleArray).matches());
+   }
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -252,7 +252,6 @@ public class TestPatternParser extends AbstractKiekerTest {
    public void testArrayParameters() throws InvalidPatternException {
       final String signatureArray = "public void package.Class.method(byte[])";
       final Pattern patternArray = PatternParser.parseToPattern("public void package.Class.method(byte[])");
-      System.out.println(patternArray);
       Assert.assertTrue(patternArray.matcher(signatureArray).matches());
 
       final String signatureDoubleArray = "public void package.Class.method(byte[][])";

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -234,7 +234,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 	}
 	
 	@Test
-   public void testByteReturn() throws InvalidPatternException {
+   public void testArrayReturn() throws InvalidPatternException {
       final String signatureByte = "public byte package.Class.method()";
       final Pattern patternByte = PatternParser.parseToPattern("public byte package.Class.method()");
       Assert.assertTrue(patternByte.matcher(signatureByte).matches());
@@ -245,6 +245,18 @@ public class TestPatternParser extends AbstractKiekerTest {
       
       final String signatureDoubleArray = "public byte[][] package.Class.method()";
       final Pattern patternDoubleArray = PatternParser.parseToPattern("public byte[][] package.Class.method()");
+      Assert.assertTrue(patternDoubleArray.matcher(signatureDoubleArray).matches());
+   }
+	
+   @Test
+   public void testArrayParameters() throws InvalidPatternException {
+      final String signatureArray = "public void package.Class.method(byte[])";
+      final Pattern patternArray = PatternParser.parseToPattern("public void package.Class.method(byte[])");
+      System.out.println(patternArray);
+      Assert.assertTrue(patternArray.matcher(signatureArray).matches());
+
+      final String signatureDoubleArray = "public void package.Class.method(byte[][])";
+      final Pattern patternDoubleArray = PatternParser.parseToPattern("public void package.Class.method(byte[][])");
       Assert.assertTrue(patternDoubleArray.matcher(signatureDoubleArray).matches());
    }
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- As return type, only Java identifiers are allowed, therefore, array-return types are not allowed. This commit fixes this by only parsing the identifier before the first [.
- This commit adds a simple test for this problem. 


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
