### PR TITLE
Allow $ in pattern in order to make inner classes adaptive monitorable

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -240,7 +240,11 @@ public final class PatternParser {
 		}
 		for (int i = 1; i < array.length; i++) {
 			if (Character.isJavaIdentifierPart(array[i])) {
-				sb.append(Character.toString(array[i]));
+				if (array[i] != '$') {
+					sb.append(array[i]);
+				} else {
+					sb.append("\\").append(array[i]);
+				}
 			} else if (array[i] == '*') {
 				sb.append("(\\p{javaJavaIdentifierPart})*");
 			} else {

--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -239,12 +239,10 @@ public final class PatternParser {
 			throw new InvalidPatternException("Identifier starts with invalid symbol.");
 		}
 		for (int i = 1; i < array.length; i++) {
-			if (Character.isJavaIdentifierPart(array[i])) {
-				if (array[i] != '$') {
-					sb.append(array[i]);
-				} else {
-					sb.append("\\").append(array[i]);
-				}
+			if (array[i] == '$') {
+				sb.append("\\").append(array[i]);
+			} else if (Character.isJavaIdentifierPart(array[i])) {
+				sb.append(array[i]);
 			} else if (array[i] == '*') {
 				sb.append("(\\p{javaJavaIdentifierPart})*");
 			} else {

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -232,6 +232,18 @@ public class TestPatternParser extends AbstractKiekerTest {
 			}
 		}
 	}
+	
+	@Test
+	public void testInnerClass() throws InvalidPatternException {
+		final String signatureInner = "public void package.Class$InnnerClass.methodA()";
+		final Pattern patternInner = PatternParser.parseToPattern("public void package.Class$InnnerClass.methodA()");
+		Assert.assertTrue(patternInner.matcher(signatureInner).matches());
+	      
+		final String signatureDoubleInner = "public void package.Class$InnnerClass$InnerClassB.methodB()";
+		final Pattern patternDoubleInner = PatternParser.parseToPattern("public void package.Class$InnnerClass$InnerClassB.methodB()");
+		Assert.assertTrue(patternDoubleInner.matcher(signatureDoubleInner).matches());
+	}
+
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- In the current implementation, $ is just ignored by the PatternParser. Calls to inner classes contain $ in their signature and should therefore be allowed. Since regular expressions take $ as sign for the end of the regex, it needs to be escaped in order to make it usable in a pattern. Unfortunately, escaping this by the user is not possible, since \ is no allowed Java-identifier-part. Therefore, this commit always escapes $ signs.
- The commit tests that calls to methods of inner classes can be identified by the pattern.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
