### PR TITLE
new should be included as part of constructor signature

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -333,7 +333,7 @@ public final class PatternParser {
 
 	private static String parseRetType(final String retType) throws InvalidPatternException {
 		if ("new".equals(retType)) {
-			return "";
+			return "(new\\s)?";
 		} else {
 			try {
 				return PatternParser.parseFQClassname(retType) + "\\s";

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -232,7 +232,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 			}
 		}
 	}
-
+	
 	@Test
 	public void testInnerClass() throws InvalidPatternException {
 		final String signatureInner = "public void package.Class$InnnerClass.methodA()";
@@ -269,6 +269,23 @@ public class TestPatternParser extends AbstractKiekerTest {
 		final Pattern patternDoubleArray = PatternParser.parseToPattern("public void package.Class.method(byte[][])");
 		Assert.assertTrue(patternDoubleArray.matcher(signatureDoubleArray).matches());
 	}
+	
+   /**
+    * Constructors signatures are often serialized as public package.Class.<init>(), but may also be serialized as
+    * public new package.Class<init>(). To let each signature be matches by the pattern created from the signature itself, 
+    * the second variant should also be accepted.
+    * @throws InvalidPatternException
+    */
+   @Test
+   public void testConstructorWithNew() throws InvalidPatternException {
+      final String signature = "public new package.Class.<init>()";
+      final Pattern withoutNewVariant = PatternParser.parseToPattern("public * package.Class.<init>()");
+      Assert.assertTrue(withoutNewVariant.matcher(signature).matches());
+      
+      final Pattern withNewVariant = PatternParser.parseToPattern("public new package.Class.<init>()");
+      Assert.assertTrue(withNewVariant.matcher(signature).matches());
+
+   }
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -232,7 +232,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 			}
 		}
 	}
-	
+
 	@Test
 	public void testInnerClass() throws InvalidPatternException {
 		final String signatureInner = "public void package.Class$InnnerClass.methodA()";
@@ -269,23 +269,24 @@ public class TestPatternParser extends AbstractKiekerTest {
 		final Pattern patternDoubleArray = PatternParser.parseToPattern("public void package.Class.method(byte[][])");
 		Assert.assertTrue(patternDoubleArray.matcher(signatureDoubleArray).matches());
 	}
-	
-   /**
-    * Constructors signatures are often serialized as public package.Class.<init>(), but may also be serialized as
-    * public new package.Class<init>(). To let each signature be matches by the pattern created from the signature itself, 
-    * the second variant should also be accepted.
-    * @throws InvalidPatternException
-    */
-   @Test
-   public void testConstructorWithNew() throws InvalidPatternException {
-      final String signature = "public new package.Class.<init>()";
-      final Pattern withoutNewVariant = PatternParser.parseToPattern("public * package.Class.<init>()");
-      Assert.assertTrue(withoutNewVariant.matcher(signature).matches());
-      
-      final Pattern withNewVariant = PatternParser.parseToPattern("public new package.Class.<init>()");
-      Assert.assertTrue(withNewVariant.matcher(signature).matches());
 
-   }
+	/**
+	 * Constructors signatures are often serialized as public package.Class.<init>(), but may also be serialized as
+	 * public new package.Class<init>(). To let each signature be matches by the pattern created from the signature itself,
+	 * the second variant should also be accepted.
+	 * 
+	 * @throws InvalidPatternException
+	 */
+	@Test
+	public void testConstructorWithNew() throws InvalidPatternException {
+		final String signature = "public new package.Class.<init>()";
+		final Pattern withoutNewVariant = PatternParser.parseToPattern("public * package.Class.<init>()");
+		Assert.assertTrue(withoutNewVariant.matcher(signature).matches());
+
+		final Pattern withNewVariant = PatternParser.parseToPattern("public new package.Class.<init>()");
+		Assert.assertTrue(withNewVariant.matcher(signature).matches());
+
+	}
 
 	@Test
 	public void constructorTest() throws InvalidPatternException {


### PR DESCRIPTION
# Pull Request

Currently, if an instrumented run is executed, constructor signatures are `public new package.Class.<init>()`. If I create a pattern from this signature, it does not match the signature itself - it is only matched by the pattern created from `public package.Class.<init>()`. To make this work, I'd suggest to add `(new\\s)?` to the pattern if `new` is passed as return type.

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1
- Contribution 2


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
