### PR TITLE
Correct strategy order

### DIFF
--- a/kieker-monitoring/src/kieker/monitoring/core/controller/WriterController.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/controller/WriterController.java
@@ -111,10 +111,10 @@ public final class WriterController extends AbstractController implements IWrite
 		if (queue instanceof BlockingQueue) {
 			this.writerQueue = (BlockingQueue<IMonitoringRecord>) queue;
 		} else {
-			final String takeStrategyFqn = configuration.getStringProperty(PREFIX + QUEUE_PUT_STRATEGY,
+			final String takeStrategyFqn = configuration.getStringProperty(PREFIX + QUEUE_TAKE_STRATEGY,
 					"kieker.monitoring.queue.takestrategy.SCBlockingTakeStrategy");
 			final TakeStrategy takeStrategy = newTakeStrategy(takeStrategyFqn);
-			final String putStrategyFqn = configuration.getStringProperty(PREFIX + QUEUE_TAKE_STRATEGY, "kieker.monitoring.queue.putstrategy.SPBlockingPutStrategy");
+			final String putStrategyFqn = configuration.getStringProperty(PREFIX + QUEUE_PUT_STRATEGY, "kieker.monitoring.queue.putstrategy.SPBlockingPutStrategy");
 			final PutStrategy putStrategy = newPutStrategy(putStrategyFqn);
 			this.writerQueue = new BlockingQueueDecorator<>(queue, putStrategy, takeStrategy);
 		}


### PR DESCRIPTION
# Pull Request

Unfortunately, the parameter for the Put-strategy to the queue specified the Take strategy and the Take-Parameter was used for the Put-strategy. This patch fixes this problem.

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1
- Contribution 2


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
