### PR TITLE
Powermock should not instrument Javas internal classes

### DIFF
--- a/kieker-monitoring/test/kieker/monitoring/core/controller/tcp/SingleSocketRecordReaderTest.java
+++ b/kieker-monitoring/test/kieker/monitoring/core/controller/tcp/SingleSocketRecordReaderTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
@@ -48,6 +49,7 @@ import kieker.common.registry.writer.WriterRegistry;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ SingleSocketRecordReader.class, AbstractTcpReader.class, SocketChannel.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class SingleSocketRecordReaderTest {
 
 	private static final int RECEIVING_PORT = 1234;


### PR DESCRIPTION
# Pull Request

In Java 11 and 15, the unit tests fail because Powermock tries to instrument Javas internal classes. They should be ignored by Powermock (as described in https://github.com/mockito/mockito/issues/1562).

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Add `@PowerMockIgnore 


## Code Quality Thresholds