### PR TITLE
Fix documentation for SystemNanoTimer's offset time unit

### DIFF
--- a/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
+++ b/kieker-monitoring/src-resources/META-INF/kieker.monitoring.default.properties
@@ -141,7 +141,7 @@ kieker.monitoring.timer.SystemMilliTimer.unit=0
 ## The offset of the timer. The time returned is since 1970-1-1 
 ## minus this offset. If the offset is empty it is set to the current 
 ## time.
-## The offset must be specified in milliseconds.
+## The offset must be specified in the given timeunit.
 kieker.monitoring.timer.SystemNanoTimer.offset=0
 ## The timeunit used to report the timestamp. 
 ## Accepted values:


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 The documentation stated that the offset of SystemNanoTimer is in milliseconds, but it is in the given timeunit. This is fixed in the documentation


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
