### PR TITLE
Fix handling of static methods for OperationExecution instrumentation

### DIFF
--- a/kieker-monitoring/integrationTest/kieker/monitoring/probe/aspectj/operationExecution/TestOperationExecutionInstrumentation.java
+++ b/kieker-monitoring/integrationTest/kieker/monitoring/probe/aspectj/operationExecution/TestOperationExecutionInstrumentation.java
@@ -40,11 +40,13 @@ public class TestOperationExecutionInstrumentation {
 		final File logFolder = Util.runTestcase(OPERATION_EXECUTION_PROJECT, "TestSimpleOperationExecution");
 
 		final List<String> lines = Util.getLatestLogRecord(logFolder);
-		final String firstSignature = lines.get(1).split(";")[2];
+		final String staticSignature = lines.get(1).split(";")[2];
+		Assert.assertEquals("public static void net.example.Instrumentable.staticMethod()", staticSignature);
+		final String firstSignature = lines.get(2).split(";")[2];
 		Assert.assertEquals("public net.example.Instrumentable.<init>()", firstSignature);
-		final String secondSignature = lines.get(2).split(";")[2];
+		final String secondSignature = lines.get(3).split(";")[2];
 		Assert.assertEquals("public void net.example.Instrumentable.callee2(java.lang.String)", secondSignature);
-		final String thirdSignature = lines.get(3).split(";")[2];
+		final String thirdSignature = lines.get(4).split(";")[2];
 		Assert.assertEquals("public void net.example.Instrumentable.callee()", thirdSignature);
 	}
 

--- a/kieker-monitoring/src/kieker/monitoring/probe/aspectj/operationExecution/AbstractOperationExecutionAspect.java
+++ b/kieker-monitoring/src/kieker/monitoring/probe/aspectj/operationExecution/AbstractOperationExecutionAspect.java
@@ -64,8 +64,8 @@ public abstract class AbstractOperationExecutionAspect extends AbstractAspectJPr
 	@Pointcut
 	public abstract void monitoredOperation();
 
-	@Before("monitoredOperation() && this(thisObject) && notWithinKieker()")
-	public void beforeOperation(final Object thisObject, final JoinPoint thisJoinPoint) throws Throwable { // NOCS
+	@Before("monitoredOperation() && notWithinKieker()")
+	public void beforeOperation(final JoinPoint thisJoinPoint) throws Throwable { // NOCS
 		if (!CTRLINST.isMonitoringEnabled()) {
 			return;
 		}

--- a/kieker-monitoring/test-resources/example-projects-aspectj/example-operationexecutionrecord/src/test/java/net/example/Instrumentable.java
+++ b/kieker-monitoring/test-resources/example-projects-aspectj/example-operationexecutionrecord/src/test/java/net/example/Instrumentable.java
@@ -1,23 +1,27 @@
 package net.example;
 
 public class Instrumentable {
-	
+
 	private final int i = 15;
-	
+
 	public Instrumentable() {
-		
+		staticMethod();
 	}
-	
+
 	public void callee() {
 		callee2("this is a test!");
 	}
-	
-	public void callee2(String someParameter) {
-		
+
+	public void callee2(final String someParameter) {
+
 	}
-	
+
 	public void throwingCallee() {
 		callee2("should be contained");
 		throw new RuntimeException("Test");
+	}
+
+	public static void staticMethod() {
+
 	}
 }


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Static methods lead to `EmptyStackException` when instrumenting with `AbstractOperationExecutionAspect`. This is fixed by correctly handling the start of an operation exection.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
