### PR TITLE
Enable AMQP messaging in Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     emfJarConfig 'org.eclipse.emf:org.eclipse.emf.ecore:2.24.0'
 
     aspectJarConfig "org.aspectj:aspectjweaver:$aspectjVersion"
+    aspectJarConfig "com.rabbitmq:amqp-client:5.13.0"
 }
 
 // We have multiple subprojects - but we do not want all of them in our JAR files.


### PR DESCRIPTION
Somehow amqp-client couldn't be loaded externally under Java 11 + AspectJ. Adding the dependency to the jar solved the problem. The problem was hard to figure out since logging with external libraries also didn't work and NO error message was printed without external logger (a System.err.println() would be useful, at least for critical errors).

Another (non-critical) problem which is not solved by this is that if the connection to RabbitMQ fails, kieker doesn't retry. This would be a nice further addition to make deployment easier.

# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- AMQP with kieker works again
- Raising awareness for dependency/logging problems with kieker under Java 11 (+ AspectJ): Everything you need has to be built into the jar file!
