### PR TITLE
Enable AMQP messaging in Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	emfJarConfig 'org.eclipse.emf:org.eclipse.emf.ecore:2.24.0'
 
 	aspectJarConfig "org.aspectj:aspectjweaver:$aspectjVersion"
+	aspectJarConfig "com.rabbitmq:amqp-client:5.13.0"
 }
 
 // We have multiple subprojects - but we do not want all of them in our JAR files.


### PR DESCRIPTION
Somehow amqp-client couldn't be loaded externally under Java 11 + AspectJ. Adding the dependency to the jar solved the problem. The problem was hard to solve since logging with external libraries also didn't work and NO error message was printed without external logger.

# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Merged dependency fix (as described above)


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
