### PR TITLE
Kieker 1913 Extend PatternParser to handle 'default' modifier

### DIFF
--- a/kieker-documentation/instrumenting-software/Adaptive-Monitoring.rst
+++ b/kieker-documentation/instrumenting-software/Adaptive-Monitoring.rst
@@ -43,12 +43,14 @@ Please note that this is going to change in the future.
   
   KiekerPattern: '*' | Modifiers ReturnType FQName '(' WS* Parameters WS* ')' Throws?
   
-  Modifiers: (Visibility WS)? (Abstract WS)? (Static WS)?
+  Modifiers: (Visibility WS)? (Abstract WS)? (Default WS)? (Static WS)?
     (Final WS)? (Synchronized WS)? (Native WS)?
   
   Visibility: "public" | "private" | "protected" | "package"
   
   Abstract: "abstract" | "non_abstract"
+  
+  Default: "default" | "non_default"
   
   Static: "static" | "non_static"
   

--- a/kieker-monitoring/gradle.properties
+++ b/kieker-monitoring/gradle.properties
@@ -5,4 +5,4 @@ findbugsErrorThreshold = 0
 findbugsWarningThreshold = 0
 
 pmdErrorThreshold = 6
-pmdWarningThreshold = 185
+pmdWarningThreshold = 189

--- a/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
+++ b/kieker-monitoring/src/kieker/monitoring/core/signaturePattern/PatternParser.java
@@ -36,8 +36,10 @@ public final class PatternParser {
 	private static final String FINAL = "final";
 	private static final String NON_STATIC = "non_static";
 	private static final String NON_ABSTRACT = "non_abstract";
+	private static final String NON_DEFAULT = "non_default";
 	private static final String STATIC = "static";
 	private static final String ABSTRACT = "abstract";
+	private static final String DEFAULT = "default";
 	private static final String PACKAGE = "package";
 	private static final String MODIFIER_PROTECTED = "protected";
 	private static final String MODIFIER_PRIVATE = "private";
@@ -54,14 +56,16 @@ public final class PatternParser {
 		ALLOWED_MODIFIER_WITH_ORDER.put(PACKAGE, 0);
 		ALLOWED_MODIFIER_WITH_ORDER.put(ABSTRACT, 1);
 		ALLOWED_MODIFIER_WITH_ORDER.put(NON_ABSTRACT, 1);
-		ALLOWED_MODIFIER_WITH_ORDER.put(STATIC, 2);
-		ALLOWED_MODIFIER_WITH_ORDER.put(NON_STATIC, 2);
-		ALLOWED_MODIFIER_WITH_ORDER.put(FINAL, 3);
-		ALLOWED_MODIFIER_WITH_ORDER.put(NON_FINAL, 3);
-		ALLOWED_MODIFIER_WITH_ORDER.put(SYNCHRONIZED, 4);
-		ALLOWED_MODIFIER_WITH_ORDER.put(NON_SYNCHRONIZED, 4);
-		ALLOWED_MODIFIER_WITH_ORDER.put(NATIVE, 5);
-		ALLOWED_MODIFIER_WITH_ORDER.put(NON_NATIVE, 5);
+		ALLOWED_MODIFIER_WITH_ORDER.put(DEFAULT, 2);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NON_DEFAULT, 2);
+		ALLOWED_MODIFIER_WITH_ORDER.put(STATIC, 3);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NON_STATIC, 3);
+		ALLOWED_MODIFIER_WITH_ORDER.put(FINAL, 4);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NON_FINAL, 4);
+		ALLOWED_MODIFIER_WITH_ORDER.put(SYNCHRONIZED, 5);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NON_SYNCHRONIZED, 5);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NATIVE, 6);
+		ALLOWED_MODIFIER_WITH_ORDER.put(NON_NATIVE, 6);
 	}
 
 	/**
@@ -383,13 +387,16 @@ public final class PatternParser {
 		case 6:
 			PatternParser.onSixModifiers(modifierList, sb);
 			break;
+		case 7:
+			PatternParser.onSevenModifiers(modifierList, sb);
+			break;
 		default:
 			throw new InvalidPatternException("Too many modifier.");
 		}
 		return sb.toString();
 	}
 
-	private static void onSixModifiers(final String[] modifierList, final StringBuilder sb)
+	private static void onSevenModifiers(final String[] modifierList, final StringBuilder sb)
 			throws InvalidPatternException {
 		PatternParser.appendScope(sb, modifierList[0], true);
 
@@ -398,23 +405,28 @@ public final class PatternParser {
 		} else if (!NON_ABSTRACT.equals(modifierList[1])) {
 			throw new InvalidPatternException("Invalid modifier.");
 		}
-		if (STATIC.equals(modifierList[2])) {
+		if (DEFAULT.equals(modifierList[2])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[2])) {
+			throw new InvalidPatternException("Invalid modifier.");
+		}
+		if (STATIC.equals(modifierList[3])) {
 			sb.append("static\\s");
-		} else if (!NON_STATIC.equals(modifierList[2])) {
+		} else if (!NON_STATIC.equals(modifierList[3])) {
 			throw new InvalidPatternException("Invalid modifier.");
 		}
-		if (FINAL.equals(modifierList[3])) {
+		if (FINAL.equals(modifierList[4])) {
 			sb.append("final\\s");
-		} else if (!NON_FINAL.equals(modifierList[3])) {
+		} else if (!NON_FINAL.equals(modifierList[4])) {
 			throw new InvalidPatternException("Invalid modifier.");
 		}
-		if (SYNCHRONIZED.equals(modifierList[4])) {
+		if (SYNCHRONIZED.equals(modifierList[5])) {
 			sb.append("synchronized\\s");
-		} else if (!NON_SYNCHRONIZED.equals(modifierList[4])) {
+		} else if (!NON_SYNCHRONIZED.equals(modifierList[5])) {
 			throw new InvalidPatternException("Invalid modifier.");
 		}
 
-		PatternParser.checkNativeFail(sb, modifierList[5]);
+		PatternParser.checkNativeFail(sb, modifierList[6]);
 	}
 
 	private static void checkNativeFail(final StringBuilder sb, final String modifier) throws InvalidPatternException {
@@ -425,6 +437,38 @@ public final class PatternParser {
 		}
 	}
 
+	private static void onSixModifiers(final String[] modifierList, final StringBuilder sb) throws InvalidPatternException {
+		PatternParser.appendScope(sb, modifierList[0], false);
+
+		if (ABSTRACT.equals(modifierList[0]) || ABSTRACT.equals(modifierList[1])) {
+			sb.append("abstract\\s");
+		} else if (!NON_ABSTRACT.equals(modifierList[0]) && !NON_ABSTRACT.equals(modifierList[1])) {
+			sb.append("(abstract\\s)?");
+		}
+		if (DEFAULT.equals(modifierList[1]) || DEFAULT.equals(modifierList[2])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[1]) && !NON_DEFAULT.equals(modifierList[2])) {
+			sb.append("(default\\s)?");
+		}
+		if (STATIC.equals(modifierList[2]) || STATIC.equals(modifierList[3])) {
+			sb.append("static\\s");
+		} else if (!NON_STATIC.equals(modifierList[2]) && !NON_STATIC.equals(modifierList[3])) {
+			sb.append("(static\\s)?");
+		}
+		if (FINAL.equals(modifierList[3]) || FINAL.equals(modifierList[4])) {
+			sb.append("final\\s");
+		} else if (!NON_FINAL.equals(modifierList[3]) && !NON_FINAL.equals(modifierList[4])) {
+			sb.append("(final\\s)?");
+		}
+		if (SYNCHRONIZED.equals(modifierList[4]) || SYNCHRONIZED.equals(modifierList[5])) {
+			sb.append("synchronized\\s");
+		} else if (!NON_SYNCHRONIZED.equals(modifierList[4]) && !NON_SYNCHRONIZED.equals(modifierList[5])) {
+			sb.append("(synchronized\\s)?");
+		}
+
+		PatternParser.checkNative(sb, modifierList[5]);
+	}
+
 	private static void onFiveModifiers(final String[] modifierList, final StringBuilder sb) throws InvalidPatternException {
 		PatternParser.appendScope(sb, modifierList[0], false);
 
@@ -433,14 +477,19 @@ public final class PatternParser {
 		} else if (!NON_ABSTRACT.equals(modifierList[0]) && !NON_ABSTRACT.equals(modifierList[1])) {
 			sb.append("(abstract\\s)?");
 		}
-		if (STATIC.equals(modifierList[1]) || STATIC.equals(modifierList[2])) {
+		if (DEFAULT.equals(modifierList[0]) || DEFAULT.equals(modifierList[1]) || DEFAULT.equals(modifierList[2])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[0]) && !NON_DEFAULT.equals(modifierList[1]) && !NON_DEFAULT.equals(modifierList[2])) {
+			sb.append("(default\\s)?");
+		}
+		if (STATIC.equals(modifierList[1]) || STATIC.equals(modifierList[2]) || STATIC.equals(modifierList[3])) {
 			sb.append("static\\s");
-		} else if (!NON_STATIC.equals(modifierList[1]) && !NON_STATIC.equals(modifierList[2])) {
+		} else if (!NON_STATIC.equals(modifierList[1]) && !NON_STATIC.equals(modifierList[2]) && !NON_STATIC.equals(modifierList[3])) {
 			sb.append("(static\\s)?");
 		}
-		if (FINAL.equals(modifierList[2]) || FINAL.equals(modifierList[3])) {
+		if (FINAL.equals(modifierList[2]) || FINAL.equals(modifierList[3]) || FINAL.equals(modifierList[4])) {
 			sb.append("final\\s");
-		} else if (!NON_FINAL.equals(modifierList[2]) && !NON_FINAL.equals(modifierList[3])) {
+		} else if (!NON_FINAL.equals(modifierList[2]) && !NON_FINAL.equals(modifierList[3]) && !NON_FINAL.equals(modifierList[4])) {
 			sb.append("(final\\s)?");
 		}
 		if (SYNCHRONIZED.equals(modifierList[3]) || SYNCHRONIZED.equals(modifierList[4])) {
@@ -460,16 +509,20 @@ public final class PatternParser {
 		} else if (!NON_ABSTRACT.equals(modifierList[0]) && !NON_ABSTRACT.equals(modifierList[1])) {
 			sb.append("(abstract\\s)?");
 		}
-		if (STATIC.equals(modifierList[0]) || STATIC.equals(modifierList[1]) || STATIC.equals(modifierList[2])) {
+		if (DEFAULT.equals(modifierList[0]) || DEFAULT.equals(modifierList[1]) || DEFAULT.equals(modifierList[2])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[0]) && !NON_DEFAULT.equals(modifierList[1]) && !NON_DEFAULT.equals(modifierList[2])) {
+			sb.append("(default\\s)?");
+		}
+		if (STATIC.equals(modifierList[0]) || STATIC.equals(modifierList[1]) || STATIC.equals(modifierList[2]) || STATIC.equals(modifierList[3])) {
 			sb.append("static\\s");
-		} else if (!NON_STATIC.equals(modifierList[0]) && !NON_STATIC.equals(modifierList[1])
-				&& !NON_STATIC.equals(modifierList[2])) {
+		} else if (!NON_STATIC.equals(modifierList[0]) && !NON_STATIC.equals(modifierList[1]) && !NON_STATIC.equals(modifierList[2])
+				&& !NON_STATIC.equals(modifierList[3])) {
 			sb.append("(static\\s)?");
 		}
 		if (FINAL.equals(modifierList[1]) || FINAL.equals(modifierList[2]) || FINAL.equals(modifierList[3])) {
 			sb.append("final\\s");
-		} else if (!NON_FINAL.equals(modifierList[1]) && !NON_FINAL.equals(modifierList[2])
-				&& !NON_FINAL.equals(modifierList[3])) {
+		} else if (!NON_FINAL.equals(modifierList[1]) && !NON_FINAL.equals(modifierList[2]) && !NON_FINAL.equals(modifierList[3])) {
 			sb.append("(final\\s)?");
 		}
 		if (SYNCHRONIZED.equals(modifierList[2]) || SYNCHRONIZED.equals(modifierList[3])) {
@@ -483,26 +536,30 @@ public final class PatternParser {
 
 	private static void onThreeModifiers(final String[] modifierList, final StringBuilder sb) throws InvalidPatternException {
 		PatternParser.appendScope(sb, modifierList[0], false);
+
 		if (ABSTRACT.equals(modifierList[0]) || ABSTRACT.equals(modifierList[1])) {
 			sb.append("abstract\\s");
 		} else if (!NON_ABSTRACT.equals(modifierList[0]) && !NON_ABSTRACT.equals(modifierList[1])) {
 			sb.append("(abstract\\s)?");
 		}
+		if (DEFAULT.equals(modifierList[0]) || DEFAULT.equals(modifierList[1]) || DEFAULT.equals(modifierList[2])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[0]) && !NON_DEFAULT.equals(modifierList[1]) && !NON_DEFAULT.equals(modifierList[2])) {
+			sb.append("(default\\s)?");
+		}
 		if (STATIC.equals(modifierList[0]) || STATIC.equals(modifierList[1]) || STATIC.equals(modifierList[2])) {
 			sb.append("static\\s");
-		} else if (!NON_STATIC.equals(modifierList[0]) && !NON_STATIC.equals(modifierList[1])
-				&& !NON_STATIC.equals(modifierList[2])) {
+		} else if (!NON_STATIC.equals(modifierList[0]) && !NON_STATIC.equals(modifierList[1]) && !NON_STATIC.equals(modifierList[2])) {
 			sb.append("(static\\s)?");
 		}
 		if (FINAL.equals(modifierList[0]) || FINAL.equals(modifierList[1]) || FINAL.equals(modifierList[2])) {
 			sb.append("final\\s");
-		} else if (!NON_FINAL.equals(modifierList[0]) && !NON_FINAL.equals(modifierList[1])
-				&& !NON_FINAL.equals(modifierList[2])) {
+		} else if (!NON_FINAL.equals(modifierList[0]) && !NON_FINAL.equals(modifierList[1]) && !NON_FINAL.equals(modifierList[2])) {
 			sb.append("(final\\s)?");
 		}
 		if (SYNCHRONIZED.equals(modifierList[1]) || SYNCHRONIZED.equals(modifierList[2])) {
 			sb.append("synchronized\\s");
-		} else if (!NON_SYNCHRONIZED.equals(modifierList[1]) && NON_SYNCHRONIZED.equals(modifierList[2])) {
+		} else if (!NON_SYNCHRONIZED.equals(modifierList[1]) && !NON_SYNCHRONIZED.equals(modifierList[2])) {
 			sb.append("(synchronized\\s)?");
 		}
 
@@ -516,6 +573,11 @@ public final class PatternParser {
 			sb.append("abstract\\s");
 		} else if (!NON_ABSTRACT.equals(modifierList[0]) && !NON_ABSTRACT.equals(modifierList[1])) {
 			sb.append("(abstract\\s)?");
+		}
+		if (DEFAULT.equals(modifierList[0]) || DEFAULT.equals(modifierList[1])) {
+			sb.append("default\\s");
+		} else if (!NON_DEFAULT.equals(modifierList[0]) && !NON_DEFAULT.equals(modifierList[1])) {
+			sb.append("(default\\s)?");
 		}
 		if (STATIC.equals(modifierList[0]) || STATIC.equals(modifierList[1])) {
 			sb.append("static\\s");
@@ -539,23 +601,25 @@ public final class PatternParser {
 	private static void onOneModifier(final String[] modifierList, final StringBuilder sb)
 			throws InvalidPatternException {
 		final String[] tokens = { MODIFIER_PUBLIC, MODIFIER_PRIVATE, MODIFIER_PROTECTED, PACKAGE,
-			ABSTRACT, NON_ABSTRACT, STATIC, NON_STATIC, FINAL, NON_FINAL, SYNCHRONIZED, NON_SYNCHRONIZED,
+			ABSTRACT, NON_ABSTRACT, DEFAULT, NON_DEFAULT, STATIC, NON_STATIC, FINAL, NON_FINAL, SYNCHRONIZED, NON_SYNCHRONIZED,
 			NATIVE, NON_NATIVE, };
 		final String[] outputs = {
-			"public\\s(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"private\\s(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"protected\\s(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?abstract\\s(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?static\\s(final\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?final\\s(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(synchronized\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(final\\s)?synchronized\\s(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(final\\s)?(native\\s)?",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?native\\s",
-			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?",
+			"public\\s(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"private\\s(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"protected\\s(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?abstract\\s(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?default\\s(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(static\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?static\\s(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(final\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?final\\s(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?(synchronized\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?synchronized\\s(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(native\\s)?",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?native\\s",
+			"((public|private|protected)\\s)?(abstract\\s)?(default\\s)?(static\\s)?(final\\s)?(synchronized\\s)?",
 		};
 
 		for (int i = 0; i < tokens.length; i++) {

--- a/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/junit/core/signaturePattern/TestPatternParser.java
@@ -44,7 +44,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 	}
 
 	@Test
-	// 160 tests
+	// 928 tests
 	public void patternTest() throws InvalidPatternException {
 		final String pattern = "public void ..Clazz.get*(int, ..) throws ..";
 		final Matcher matcher = PatternParser.parseToPattern(pattern).matcher("");
@@ -52,6 +52,7 @@ public class TestPatternParser extends AbstractKiekerTest {
 		final SignatureConstructor positiveSignature = new SignatureConstructor();
 		positiveSignature.addVisibilityVariant("public")
 				.addAbstractNonAbstractVariant("").addAbstractNonAbstractVariant("abstract")
+				.addDefaultNonDefaultVariant("").addDefaultNonDefaultVariant("default")
 				.addStaticNonStaticVariant("").addStaticNonStaticVariant("static")
 				.addFinalNonFinalVariant("").addFinalNonFinalVariant("final")
 				.addSynchronizedNonSynchronizedVariant("").addSynchronizedNonSynchronizedVariant("synchronized")
@@ -231,6 +232,13 @@ public class TestPatternParser extends AbstractKiekerTest {
 				}
 			}
 		}
+	}
+
+	@Test
+	public void testDefaultModifier() throws InvalidPatternException {
+		final String signature = "public default void package.Interface.method()";
+		final Pattern pattern = PatternParser.parseToPattern("default ..* package.Interface.method(..)");
+		Assert.assertTrue(pattern.matcher(signature).matches());
 	}
 
 	@Test

--- a/kieker-monitoring/test/kieker/test/monitoring/util/signaturePattern/SignatureConstructor.java
+++ b/kieker-monitoring/test/kieker/test/monitoring/util/signaturePattern/SignatureConstructor.java
@@ -31,6 +31,7 @@ public final class SignatureConstructor {
 
 	private static final String DEFAULT_VISIBILITY = "";
 	private static final String DEFAULT_ABSTRACT_NON_ABSTRACT = "";
+	private static final String DEFAULT_DEFAULT_NON_DEFAULT = "";
 	private static final String DEFAULT_STATIC_NON_STATIC = "";
 	private static final String DEFAULT_FINAL_NON_FINAL = "";
 	private static final String DEFAULT_SYNCHRONIZED_NON_SYNCHRONIZED = "";
@@ -43,6 +44,7 @@ public final class SignatureConstructor {
 
 	private final List<String> visibilityList = new ArrayList<>();
 	private final List<String> abstractNonAbstractList = new ArrayList<>();
+	private final List<String> defaultNonDefaultList = new ArrayList<>();
 	private final List<String> staticNonStaticList = new ArrayList<>();
 	private final List<String> finalNonFinalList = new ArrayList<>();
 	private final List<String> synchronizedNonSynchronizedList = new ArrayList<>();
@@ -71,6 +73,9 @@ public final class SignatureConstructor {
 		}
 		if (this.abstractNonAbstractList.isEmpty()) {
 			this.abstractNonAbstractList.add(SignatureConstructor.DEFAULT_ABSTRACT_NON_ABSTRACT);
+		}
+		if (this.defaultNonDefaultList.isEmpty()) {
+			this.defaultNonDefaultList.add(SignatureConstructor.DEFAULT_DEFAULT_NON_DEFAULT);
 		}
 		if (this.staticNonStaticList.isEmpty()) {
 			this.staticNonStaticList.add(SignatureConstructor.DEFAULT_STATIC_NON_STATIC);
@@ -102,42 +107,47 @@ public final class SignatureConstructor {
 		final List<String> result = new ArrayList<>();
 		for (final String visibility : this.visibilityList) { // NOCS
 			for (final String abstractNonAbstract : this.abstractNonAbstractList) {
-				for (final String staticNonStatic : this.staticNonStaticList) { // NOCS
-					for (final String finalNonFinal : this.finalNonFinalList) { // NOCS
-						for (final String synchronizedNonSynchronized : this.synchronizedNonSynchronizedList) { // NOCS
-							for (final String nativeNonNative : this.nativeNonNativeList) { // NOCS
-								for (final String returnType : this.returnTypeList) { // NOCS
-									for (final String fqClassName : this.fqClassNameList) { // NOCS
-										for (final String operationName : this.operationNameList) { // NOCS
-											for (final String paramList : this.parameterListList) { // NOCS
-												for (final String throwsList : this.throwsListList) { // NOCS
-													final StringBuilder sb = new StringBuilder();
-													if (visibility.length() > 0) {
-														sb.append(visibility).append(' ');
+				for (final String defaultNonDefault : this.defaultNonDefaultList) {
+					for (final String staticNonStatic : this.staticNonStaticList) { // NOCS
+						for (final String finalNonFinal : this.finalNonFinalList) { // NOCS
+							for (final String synchronizedNonSynchronized : this.synchronizedNonSynchronizedList) { // NOCS
+								for (final String nativeNonNative : this.nativeNonNativeList) { // NOCS
+									for (final String returnType : this.returnTypeList) { // NOCS
+										for (final String fqClassName : this.fqClassNameList) { // NOCS
+											for (final String operationName : this.operationNameList) { // NOCS
+												for (final String paramList : this.parameterListList) { // NOCS
+													for (final String throwsList : this.throwsListList) { // NOCS
+														final StringBuilder sb = new StringBuilder();
+														if (visibility.length() > 0) {
+															sb.append(visibility).append(' ');
+														}
+														if (abstractNonAbstract.length() > 0) {
+															sb.append(abstractNonAbstract).append(' ');
+														}
+														if (defaultNonDefault.length() > 0) {
+															sb.append(defaultNonDefault).append(' ');
+														}
+														if (staticNonStatic.length() > 0) {
+															sb.append(staticNonStatic).append(' ');
+														}
+														if (finalNonFinal.length() > 0) {
+															sb.append(finalNonFinal).append(' ');
+														}
+														if (synchronizedNonSynchronized.length() > 0) {
+															sb.append(synchronizedNonSynchronized).append(' ');
+														}
+														if (nativeNonNative.length() > 0) {
+															sb.append(nativeNonNative).append(' ');
+														}
+														if (returnType.length() > 0) {
+															sb.append(returnType).append(' ');
+														}
+														sb.append(fqClassName).append('.').append(operationName).append('(').append(paramList).append(')');
+														if (throwsList.length() > 0) {
+															sb.append(" throws ").append(throwsList);
+														}
+														result.add(sb.toString());
 													}
-													if (abstractNonAbstract.length() > 0) {
-														sb.append(abstractNonAbstract).append(' ');
-													}
-													if (staticNonStatic.length() > 0) {
-														sb.append(staticNonStatic).append(' ');
-													}
-													if (finalNonFinal.length() > 0) {
-														sb.append(finalNonFinal).append(' ');
-													}
-													if (synchronizedNonSynchronized.length() > 0) {
-														sb.append(synchronizedNonSynchronized).append(' ');
-													}
-													if (nativeNonNative.length() > 0) {
-														sb.append(nativeNonNative).append(' ');
-													}
-													if (returnType.length() > 0) {
-														sb.append(returnType).append(' ');
-													}
-													sb.append(fqClassName).append('.').append(operationName).append('(').append(paramList).append(')');
-													if (throwsList.length() > 0) {
-														sb.append(" throws ").append(throwsList);
-													}
-													result.add(sb.toString());
 												}
 											}
 										}
@@ -175,6 +185,19 @@ public final class SignatureConstructor {
 	 */
 	public SignatureConstructor addAbstractNonAbstractVariant(final String abstractNonAbstract) {
 		this.abstractNonAbstractList.add(abstractNonAbstract);
+		return this;
+	}
+
+	/**
+	 * Adds the given string as a default or non default variant.
+	 *
+	 * @param defaultNonDefault
+	 *            The default or non default variant.
+	 *
+	 * @return A reference to {@code this} in order to allow the chaining of the methods.
+	 */
+	public SignatureConstructor addDefaultNonDefaultVariant(final String defaultNonDefault) {
+		this.defaultNonDefaultList.add(defaultNonDefault);
 		return this;
 	}
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Extend PatternParser to handle 'default' modifier


## Code Quality Thresholds
- [x] It was necessary to raise any code quality thresholds
- PMD warning threshold of kieker-monitoring module needed to be raised from 185 to 189, because
1. new method 'onSevenModifiers' introduces same warnings as existing methods 'onSixModifiers', 'onFiveModifiers', ...
2. Although making only small changes, class 'SignatureConstructor' is a possible god class now 

