### PR TITLE
Kieker 1917 Fix Examples in Distribution Run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -812,34 +812,20 @@ def exampleJavaEEContent = project.copySpec {
 	into kiekerPackagenamebase + "-" + kiekerVersion + "/examples/JavaEEServletContainerExample/jetty"
 }
 
-// Build the examples separately
-task prepareExamplesForDistribution(dependsOn: ['kieker-examples:buildStandaloneExamples']) {
-	doLast {
-	}
-}
-
-/**
-* Compile the binary distribution.
-*/
-
 /** binary distribution in zip format. */
-task distributeBinaryZip(type: Zip, group: 'distribution', description: 'Distributes binary archive.', dependsOn: [mainJar, emfJar, aspectJJar, sourcesJar, javadocJar, prepareExamplesForDistribution]) {
+task distributeBinaryZip(type: Zip, group: 'distribution', description: 'Distributes binary archive.', dependsOn: [mainJar, emfJar, aspectJJar, sourcesJar, javadocJar, 'kieker-examples:buildStandaloneExamples']) {
 	classifier = 'binaries'
 	with binaryContent, toolsContent, libraryContent, exampleContent, exampleJavaEEContent
 }
 
 /** binary distribution in tar.gz format. */
-task distributeBinaryTar(type: Tar, group: 'distribution', description: 'Distributes binary archive.', dependsOn: [mainJar, emfJar, aspectJJar, sourcesJar, javadocJar, prepareExamplesForDistribution]) {
+task distributeBinaryTar(type: Tar, group: 'distribution', description: 'Distributes binary archive.', dependsOn: [mainJar, emfJar, aspectJJar, sourcesJar, javadocJar, 'kieker-examples:buildStandaloneExamples']) {
 	classifier = 'binaries'
 	with binaryContent, toolsContent, libraryContent, exampleContent, exampleJavaEEContent
 
 	compression = Compression.GZIP
 	archiveExtension = 'tar.gz'
 }
-
-/**
-* Collect source content.
-*/
 
 /** collect all sources. */
 def sourceContent = project.copySpec {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kieker-examples/build.gradle
+++ b/kieker-examples/build.gradle
@@ -289,8 +289,6 @@ task cleanStandaloneExamples(dependsOn: [
 	]) {
 }
 
-clean.dependsOn cleanStandaloneExamples
-
 task cleanStandaloneExamplesUserguideCh2App(type: GradleBuild) {
 	buildFile = 'userguide/bookstore-application/build.gradle'
 	tasks = ['clean']

--- a/kieker-examples/build.gradle
+++ b/kieker-examples/build.gradle
@@ -195,7 +195,7 @@ task buildStandaloneExamplesMonitoringJVM(type: GradleBuild, dependsOn: 'copyLib
 // Spring tutorial example
 task copyLibsStandaloneExamplesMonitoringSpring(type: Copy, dependsOn: [rootProject.mainJar]) {
 	from ('../build/libs') {
-		include "kieker-${version}-jar.jar"
+		include "kieker-${version}.jar"
 	}
 	from ('../lib') {
 		include "aspectjweaver-*.jar"
@@ -211,7 +211,7 @@ task buildStandaloneExamplesMonitoringSpring(type: GradleBuild, dependsOn: 'copy
 //
 task copyLibsStandaloneExamplesMonitoringManual(type: Copy, dependsOn: [rootProject.mainJar]) {
 	from ('../build/libs') {
-		include "kieker-${version}-jar.jar"
+		include "kieker-${version}.jar"
 	}
 	into 'monitoring/probe-manual/lib/'
 }
@@ -244,6 +244,8 @@ task buildStandaloneExamplesMonitoringAdaptive(type: GradleBuild, dependsOn: 'co
 	buildFile = 'monitoring/adaptive-monitoring/build.gradle'
 	tasks = ['jar']
 }
+
+
 
 task copyLibsStandaloneExamplesMonitoringTimesource(type: Copy, dependsOn: [rootProject.aspectJJar]) {
 	from ('../build/libs') {

--- a/kieker-examples/monitoring/adaptive-monitoring/build.gradle
+++ b/kieker-examples/monitoring/adaptive-monitoring/build.gradle
@@ -14,8 +14,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-    implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
-
 	implementation fileTree('lib') {
 		include "lib/kieker-1.15.1-aspectj.jar"
 	}

--- a/kieker-examples/monitoring/adaptive-monitoring/build.gradle
+++ b/kieker-examples/monitoring/adaptive-monitoring/build.gradle
@@ -14,9 +14,10 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-	implementation fileTree('lib') {
-		include "lib/kieker-1.15.1-aspectj.jar"
-	}
+    // This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
+    implementation fileTree('lib') {
+        include "lib/kieker-1.15.1-aspectj.jar"
+    }
 }
 
 distTar.enabled=false
@@ -39,6 +40,8 @@ jar {
 task runMonitoring(type: JavaExec) {
 	main = mainClassName
 	classpath = sourceSets.main.runtimeClasspath
+	
+	// The path to the javaagent file might be replaced by ${System.properties['user.home']}/.m2/repository/net/kieker-monitoring/kieker/${kiekerVersion}/kieker-${kiekerVersion}-aspectj.jar if the jar is in the local maven repository
 	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
 	           "-javaagent:lib/kieker-1.15.1-aspectj.jar",
 			   '-Dorg.aspectj.weaver.showWeaveInfo=true',

--- a/kieker-examples/monitoring/adaptive-monitoring/build.gradle
+++ b/kieker-examples/monitoring/adaptive-monitoring/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     // This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
     implementation fileTree('lib') {
-        include "lib/kieker-1.15.1-aspectj.jar"
+        include "lib/kieker-${kiekerVersion}-aspectj.jar"
     }
 }
 
@@ -43,7 +43,7 @@ task runMonitoring(type: JavaExec) {
 	
 	// The path to the javaagent file might be replaced by ${System.properties['user.home']}/.m2/repository/net/kieker-monitoring/kieker/${kiekerVersion}/kieker-${kiekerVersion}-aspectj.jar if the jar is in the local maven repository
 	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
-	           "-javaagent:lib/kieker-1.15.1-aspectj.jar",
+	           "-javaagent:lib/kieker-${kiekerVersion}-aspectj.jar",
 			   '-Dorg.aspectj.weaver.showWeaveInfo=true',
 			   '-Daj.weaving.verbose=true',
 			   '-Dkieker.monitoring.adaptiveMonitoring.enabled=true',

--- a/kieker-examples/monitoring/custom-timesource/build.gradle
+++ b/kieker-examples/monitoring/custom-timesource/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-    implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
-
     // you need to ensure by yourself that the following jars are in the lib folder
     implementation fileTree('lib') {
         include "kieker-*.jar"

--- a/kieker-examples/monitoring/custom-timesource/build.gradle
+++ b/kieker-examples/monitoring/custom-timesource/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     // you need to ensure by yourself that the following jars are in the lib folder
     // This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
     implementation fileTree('lib') {
-        include "kieker-*.jar"
+        include "kieker-${kiekerVersion}-aspectj.jar"
     }
 }
 
@@ -43,7 +43,7 @@ task runMonitoring(type: JavaExec) {
 	// The path to the javaagent file might be replaced by ${System.properties['user.home']}/.m2/repository/net/kieker-monitoring/kieker/${kiekerVersion}/kieker-${kiekerVersion}-aspectj.jar if the jar is in the local maven repository
 	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
 			   '-Dkieker.monitoring.timer=kieker.monitoring.timer.CustomTimeSource',
-	           "-javaagent:lib/kieker-1.15.1-aspectj.jar",
+	           "-javaagent:lib/kieker-${kiekerVersion}-aspectj.jar",
 			   '-Dorg.aspectj.weaver.showWeaveInfo=true',
 			   '-Daj.weaving.verbose=true']
 }

--- a/kieker-examples/monitoring/custom-timesource/build.gradle
+++ b/kieker-examples/monitoring/custom-timesource/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
     // you need to ensure by yourself that the following jars are in the lib folder
+    // This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
     implementation fileTree('lib') {
         include "kieker-*.jar"
     }
@@ -38,6 +39,8 @@ jar {
 task runMonitoring(type: JavaExec) {
 	main = mainClassName
 	classpath = sourceSets.main.runtimeClasspath
+	
+	// The path to the javaagent file might be replaced by ${System.properties['user.home']}/.m2/repository/net/kieker-monitoring/kieker/${kiekerVersion}/kieker-${kiekerVersion}-aspectj.jar if the jar is in the local maven repository
 	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
 			   '-Dkieker.monitoring.timer=kieker.monitoring.timer.CustomTimeSource',
 	           "-javaagent:lib/kieker-1.15.1-aspectj.jar",

--- a/kieker-examples/monitoring/probe-aspectj/build.gradle
+++ b/kieker-examples/monitoring/probe-aspectj/build.gradle
@@ -13,7 +13,8 @@ dependencies {
         implementation 'ch.qos.logback:logback-classic:1.1.7'
         implementation 'org.slf4j:slf4j-api:1.7.30'
         implementation 'org.codehaus.groovy:groovy-all:3.0.2'
-
+	
+	// This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
 	implementation fileTree('lib') {
 		include "kieker-${kiekerVersion}-aspectj.jar"
 	}
@@ -39,6 +40,7 @@ jar {
 task runMonitoring(type: JavaExec) {
 	main = mainClassName
 	classpath = sourceSets.main.runtimeClasspath
+	// The path to the javaagent file might be replaced by ${System.properties['user.home']}/.m2/repository/net/kieker-monitoring/kieker/${kiekerVersion}/kieker-${kiekerVersion}-aspectj.jar if the jar is in the local maven repository
 	jvmArgs = ['-Dkieker.monitoring.writer.filesystem.FileWriter.customStoragePath=monitoring-logs',
 	           "-javaagent:lib/kieker-${kiekerVersion}-aspectj.jar",
 			   '-Dorg.aspectj.weaver.showWeaveInfo=true',

--- a/kieker-examples/monitoring/probe-aspectj/build.gradle
+++ b/kieker-examples/monitoring/probe-aspectj/build.gradle
@@ -14,8 +14,6 @@ dependencies {
         implementation 'org.slf4j:slf4j-api:1.7.30'
         implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-	implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
-
 	implementation fileTree('lib') {
 		include "kieker-${kiekerVersion}-aspectj.jar"
 	}

--- a/kieker-examples/monitoring/probe-manual/build.gradle
+++ b/kieker-examples/monitoring/probe-manual/build.gradle
@@ -14,7 +14,6 @@ dependencies {
         implementation 'org.slf4j:slf4j-api:1.7.30'
         implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-	implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
 	implementation fileTree('lib') {
                 include 'kieker-*.jar'
         }

--- a/kieker-examples/monitoring/probe-spring/build.gradle
+++ b/kieker-examples/monitoring/probe-spring/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	// https://mvnrepository.com/artifact/commons-logging/commons-logging
 	runtimeOnly 'commons-logging:commons-logging:1.2'
 	
+	// This might be replaced by implementation "net.kieker-monitoring:kieker:${kiekerVersion}" if the jar is in the local maven repository
 	runtimeOnly fileTree('lib') {
 		include "kieker-*-aspectj.jar"
 	}

--- a/kieker-examples/monitoring/probe-spring/build.gradle
+++ b/kieker-examples/monitoring/probe-spring/build.gradle
@@ -19,7 +19,6 @@ dependencies {
         implementation 'org.slf4j:slf4j-api:1.7.30'
         implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-	implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
 	implementation 'org.jctools:jctools-core:2.1.0'
 
 	// https://mvnrepository.com/artifact/org.springframework/spring-expression

--- a/kieker-examples/monitoring/sampler-jvm/build.gradle
+++ b/kieker-examples/monitoring/sampler-jvm/build.gradle
@@ -14,8 +14,6 @@ dependencies {
         implementation 'org.slf4j:slf4j-api:1.7.30'
         implementation 'org.codehaus.groovy:groovy-all:3.0.2'
 
-	implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
-
         // you need to ensure by yourself that the following jars are in the lib folder
         implementation fileTree('lib') {
                 include "kieker-*.jar"


### PR DESCRIPTION
# Pull Request
As discussed, I completed the changes from the meetings. Now, the build works (at least for me) locally. It was not necessary to remove `cleanStandaloneExamples` as default task. Could you check whether this works for you?

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Fix `./gradlew -x test -x check clean distribute`: Remove `clean.dependsOn cleanStandaloneExamples`
- Contribution 2 Remove `prepareExamplesForDistribution` task
- Contribution 3 Remove implementation dependency from example `build.gradle`, since the dependency from `lib` should be used


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
