### PR TITLE
Bugfix with Windows line endings when parsing records

### DIFF
--- a/kieker-analysis/src/kieker/analysis/generic/source/file/DatEventDeserializer.java
+++ b/kieker-analysis/src/kieker/analysis/generic/source/file/DatEventDeserializer.java
@@ -116,6 +116,11 @@ public class DatEventDeserializer extends AbstractEventDeserializer {
 				this.createRecord(outputPort);
 				mark = i;
 			} else if (ch == '\r') {
+				if (i + 1 == numOfBufferedBytes) {
+					// end of the line has not been reached but it will be tried to go over the buffer.
+					// this cannot be allowed, returning the mark prematurely will allow the buffer to read the line again.
+					return mark;
+				}
 				if (buffer[i + 1] == '\n') {
 					i++;
 				}

--- a/kieker-analysis/test/kieker/analysis/generic/source/file/DatEventDeserializerTest.java
+++ b/kieker-analysis/test/kieker/analysis/generic/source/file/DatEventDeserializerTest.java
@@ -1,0 +1,89 @@
+/***************************************************************************
+ * Copyright 2022 Kieker Project (http://kieker-monitoring.net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+package kieker.analysis.generic.source.file;
+
+import kieker.analysis.plugin.reader.newio.deserializer.DeserializerStringRegistry;
+import kieker.common.record.IMonitoringRecord;
+import org.junit.Test;
+import teetime.framework.OutputPort;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.mock;
+/**
+ * @author Clemens Kurz
+ *
+ * @since 2.0.0
+ */
+public class DatEventDeserializerTest {
+
+
+    /**
+     * Create test object.
+     */
+    public DatEventDeserializerTest() {
+        // nothing to do
+    }
+
+    /**
+     * A simple record with '\r' at the end.
+     */
+    private final static String RECORD = "$0;1693267380061362600;1.15-SNAPSHOT;KIEKER;6d672498b3fb;1;false;0;NANOSECONDS;0\r";
+
+    /**
+     * Buffer Size is chosen by the length of the first event + \r
+     * this case ensures that the second trace can only be read if (and only if) the edge case is handled correctly
+     * The Edge case is that the buffer lands between \r\n and tries to recognize \n and
+     * does not run into an ArrayIndexOutOfBoundsException
+      * @throws IOException
+     */
+    @Test
+    public void testCarriageReturnLineFeedIsNoteSeperatedByTheBufferSize() throws IOException {
+        // setup
+        final int bufferSize = RECORD.getBytes().length;
+
+        final ArrayList<String> values = new ArrayList<>();
+        values.add("myClass"); // is required for the record to find a class and the Charset to get cleared.
+        final DeserializerStringRegistry registry = new DeserializerStringRegistry(values);
+        final DatEventDeserializer datEventDeserializer = new DatEventDeserializer(bufferSize, registry);
+
+        final OutputPort<IMonitoringRecord> outputPort = mock(OutputPort.class);
+
+        // test
+        // The record is applied twice since the read bytes are read twice and the end od the array must be reached.
+        try (final InputStream is = new ByteArrayInputStream((RECORD + RECORD).getBytes())) {
+            datEventDeserializer.processDataStream(is, outputPort);
+        }
+        // TODO: verify a bit unclear how to do since we could only check side effects and
+        //  internal code of the class does not reach the point where the OutputPort.send Method is called.
+    }
+
+    private static String stringWithCharacterLength(final int bufferSize) {
+        char[] chars = new char[bufferSize * 2];
+        for (int i = 0; i < chars.length; i++) {
+            if ((i + 1) % 25 == 0) {
+                chars[i] = '\r';
+            } else {
+                chars[i] = 'a';
+            }
+        }
+        return new String(chars);
+    }
+
+}

--- a/kieker-analysis/test/kieker/analysis/generic/source/file/DatEventDeserializerTest.java
+++ b/kieker-analysis/test/kieker/analysis/generic/source/file/DatEventDeserializerTest.java
@@ -74,16 +74,4 @@ public class DatEventDeserializerTest {
         //  internal code of the class does not reach the point where the OutputPort.send Method is called.
     }
 
-    private static String stringWithCharacterLength(final int bufferSize) {
-        char[] chars = new char[bufferSize * 2];
-        for (int i = 0; i < chars.length; i++) {
-            if ((i + 1) % 25 == 0) {
-                chars[i] = '\r';
-            } else {
-                chars[i] = 'a';
-            }
-        }
-        return new String(chars);
-    }
-
 }


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Fix for a Bug in an Edge-Case where the parsing of Traces causes an ArrayIndexOutOfBoundsException
- A simple test for this edge case that will fail in case the edge case is reached, however does not ensure that the class operates correctly and parses all records
- Documentation of how and why this bug occurs is in the code.