### PR TITLE
Fix AspectJJar - include :monitoring:aspectj also 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ def mainSubprojects = [
   project(':extension-cassandra')
 ]
 
+def aspectJSubprojects = [
+  project(':common'),
+  project(':monitoring:core'),
+  project(':monitoring:aspectj')
+]
+
 allprojects {
   version = kiekerVersion
 
@@ -606,6 +612,14 @@ def allArtifacts = {
   }
 }
 
+def aspectJArtifacts = {
+  aspectJSubprojects.each { subproject ->
+    from subproject.configurations.archives.allArtifacts.files.collect {
+      zipTree(it)
+    }
+  }
+}
+
 def licence = {
   from file('LICENSE')
 }
@@ -677,12 +691,12 @@ task emfJar(type: Jar, dependsOn: mainSubprojects.tasks["build"], group: "build"
 }
 
 /** Kieker jar with aspectJ tooling. */
-task aspectJJar(type: Jar, dependsOn: mainSubprojects.tasks["build"], group: "build",
+task aspectJJar(type: Jar, dependsOn: aspectJSubprojects.tasks["build"], group: "build",
     description: "Assembles a jar archive containing the contents of the mainJar task and additionally the aspect-oriented framework AspectJ. The resulting jar can directly be used for monitoring as javaagent."
 ) {
   // default archiveFileName is [baseName]-[appendix]-[version]-[classifier].[extension]
   archiveClassifier = 'aspectj'
-  configure allArtifacts
+  configure aspectJArtifacts
   configure licence
   configure aopxml
 


### PR DESCRIPTION
# Pull Request

Currently, all PRs and MooBench are failing since the AspectJ classes are not included in the AspectJ jar. This is caused by the fact that there are `mainSubprojects`, but these do not contain `:monitoring:aspectj` (which makes sense, since AspectJ provide one set of probes for a `-javaagent` jar, but I wouldn't consider it a main subproject). 

To fix this, I've created aspectJSubprojects, that include `:monitoring:aspectj' and the required dependencies, but nothing else. For some time, the aspectj jar contained *everything*, including analysis etc. - this problem is fixed by this PR as well.

However, this is not really an ideal solutions, since:
- We duplicate the dependency configuration of the AspectJ probe jar (the `:monitoring:aspectj` module itself already specifies the dependencies it needs, and now the `aspectJSubprojects` list does this as well
- This structure becomes very verbose and hard to maintain, as soon as we provide probe jars for ByteBuddy and Javassist as well.

Nevertheless, since we shouldn't have unusable snapshots, I'll merge this for now to fix this issue. We can think about a long term solution later.

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Fixes the problem that the AspectJJar is unusable since its classes are missing. 


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
