### PR TITLE
Remove unused function in release-check-extended.sh

### DIFF
--- a/bin/dev/release-check-extended.sh
+++ b/bin/dev/release-check-extended.sh
@@ -12,15 +12,6 @@ source "${BIN_DIR}/release-check-common.sh"
 # 55=Java 11
 javaVersion="major version: 55"
 
-# build with ant (target may be passed as $1)
-function run_gradle {
-	information "Trying to invoke gradle with target '$1' ..."
-	if ! ./gradlew -S $1; then
-		error "Gradle build failed"
-		exit 1
-	fi
-}
-
 # extract archive to a specific location
 function extract_archive_to {
 	if [ -z "$1" ]; then


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Remove the function `run_gradle`, that is never used in the script (and documented that it runs ant...)


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
