### PR TITLE
Kieker 1986 kieker release check build fails

### DIFF
--- a/examples/monitoring/probe-aspectj/build.gradle
+++ b/examples/monitoring/probe-aspectj/build.gradle
@@ -12,8 +12,6 @@ dependencies {
         implementation "ch.qos.logback:logback-classic:$libLogbackVersion"
         implementation "org.slf4j:slf4j-api:1.7.30"
         implementation "org.codehaus.groovy:groovy-all:3.0.2"
-
-        implementation "net.kieker-monitoring:kieker:${kiekerVersion}"
 }
 
 distTar.enabled=false

--- a/monitoring/aspectj/build.gradle
+++ b/monitoring/aspectj/build.gradle
@@ -196,11 +196,6 @@ compileJarIntegrationTestJava {
 	}
 }
 
-def resolveLibrary(String library) {
-def libraryDir = rootProject.file(dirLib)
-return fileTree(dir: libraryDir, include: library).filter { it.isFile() }
-}
-
 // This is necessary to avoid eclipse problems; eclipse does not allow the same project to be imported twice as dependency
 eclipse {
 	classpath {

--- a/monitoring/bytebuddy/build.gradle
+++ b/monitoring/bytebuddy/build.gradle
@@ -28,12 +28,6 @@ dependencies {
 	testImplementation "junit:junit:$libJunitVersion"
 }
 
-
-def resolveLibrary(String library) {
-def libraryDir = rootProject.file(dirLib)
-return fileTree(dir: libraryDir, include: library).filter { it.isFile() }
-}
-
 // This is necessary to avoid eclipse problems; eclipse does not allow the same project to be imported twice as dependency
 eclipse {
 	classpath {

--- a/monitoring/core/build.gradle
+++ b/monitoring/core/build.gradle
@@ -141,11 +141,6 @@ publishing {
 	}
 }
 
-def resolveLibrary(String library) {
-def libraryDir = rootProject.file(dirLib)
-return fileTree(dir: libraryDir, include: library).filter { it.isFile() }
-}
-
 // This is necessary to avoid eclipse problems; eclipse does not allow the same project to be imported twice as dependency
 eclipse {
 	classpath {


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Release check extended currently fails due to an unnecessary dependency. This PR removes it
- Contribution 2 Additionally, unused gradle methods are removed.


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
