### PR TITLE
Kieker 1986 kieker release check build fails

### DIFF
--- a/bin/dev/Jenkinsfile-TestVersionChange
+++ b/bin/dev/Jenkinsfile-TestVersionChange
@@ -48,6 +48,7 @@ pipeline {
         stage('Change Version Number') {
           steps {
             sh "sed -i 's/kiekerVersion = .*/kiekerVersion = 99.9/g' gradle.properties"
+            sh "sed -i 's/KIEKER_VERSION=\".*\"/KIEKER_VERSION=\"99.9\"/g' bin/dev/*.sh"
             sh 'cat gradle.properties'
           }
         }

--- a/bin/dev/Jenkinsfile-TestVersionChange
+++ b/bin/dev/Jenkinsfile-TestVersionChange
@@ -62,7 +62,7 @@ pipeline {
 
         stage('Distribution Build') {
           steps {
-            sh './gradlew -x test -x signMavenJavaPublication build distribute publishToMavenLocal -Pskip.signing'
+            sh './gradlew -x test build distribute publishToMavenLocal'
             sh 'bin/dev/assemble-tools.sh'
             stash includes: 'build/libs/*.jar', name: 'jarArtifacts'
             stash includes: 'build/distributions/*', name: 'distributions'

--- a/bin/dev/Jenkinsfile-TestVersionChange
+++ b/bin/dev/Jenkinsfile-TestVersionChange
@@ -62,7 +62,7 @@ pipeline {
 
         stage('Distribution Build') {
           steps {
-            sh './gradlew -x test build distribute publishToMavenLocal'
+            sh './gradlew -x test -x signMavenJavaPublication build distribute'
             sh 'bin/dev/assemble-tools.sh'
             stash includes: 'build/libs/*.jar', name: 'jarArtifacts'
             stash includes: 'build/distributions/*', name: 'distributions'

--- a/bin/dev/assemble-tools-architecture-recovery.sh
+++ b/bin/dev/assemble-tools-architecture-recovery.sh
@@ -3,7 +3,7 @@
 BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
 BASE_DIR="${BIN_DIR}/../.."
-VERSION="2.0.0-SNAPSHOT"
+KIEKER_VERSION="2.0.0-SNAPSHOT"
 
 PACKAGE_NAME=architecture-recovery
 BUILD_PATH="${BASE_DIR}/build/${PACKAGE_NAME}"
@@ -20,15 +20,15 @@ mkdir bin
 mkdir lib
 
 for I in allen-upper-limit cmi dar delta fxca maa mktable mop mt mvis sar relabel restructuring ; do
-	unzip "${KIEKER_TOOLS}/$I/build/distributions/$I-$VERSION.zip"
-	mv "$I-$VERSION/lib/"* lib/
-	mv "$I-$VERSION/bin/"* bin/
-	rm -rf "$I-$VERSION"
+	unzip "${KIEKER_TOOLS}/$I/build/distributions/$I-$KIEKER_VERSION.zip"
+	mv "$I-$KIEKER_VERSION/lib/"* lib/
+	mv "$I-$KIEKER_VERSION/bin/"* bin/
+	rm -rf "$I-$KIEKER_VERSION"
 done
 
 cd ..
-tar -cvzpf "${BUILD_PATH}-${VERSION}.tgz" "${PACKAGE_NAME}"
-zip -r "${BUILD_PATH}-${VERSION}.zip" "${PACKAGE_NAME}"
+tar -cvzpf "${BUILD_PATH}-${KIEKER_VERSION}.tgz" "${PACKAGE_NAME}"
+zip -r "${BUILD_PATH}-${KIEKER_VERSION}.zip" "${PACKAGE_NAME}"
 
 rm -rf "${BUILD_PATH}"
 

--- a/bin/dev/assemble-tools-trace-analysis.sh
+++ b/bin/dev/assemble-tools-trace-analysis.sh
@@ -3,7 +3,7 @@
 BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
 BASE_DIR="${BIN_DIR}/../.."
-VERSION="2.0.0-SNAPSHOT"
+KIEKER_VERSION="2.0.0-SNAPSHOT"
 
 PACKAGE_NAME=trace-analysis
 BUILD_PATH="${BASE_DIR}/build/${PACKAGE_NAME}"

--- a/bin/dev/assemble-tools-trace-analysis.sh
+++ b/bin/dev/assemble-tools-trace-analysis.sh
@@ -20,15 +20,15 @@ mkdir bin
 mkdir lib
 
 for I in trace-analysis trace-analysis-gui ; do
-	unzip "${KIEKER_TOOLS}/$I/build/distributions/$I-$VERSION.zip"
-	mv "$I-$VERSION/lib/"* lib/
-	mv "$I-$VERSION/bin/"* bin/
-	rm -rf "$I-$VERSION"
+	unzip "${KIEKER_TOOLS}/$I/build/distributions/$I-$KIEKER_VERSION.zip"
+	mv "$I-$KIEKER_VERSION/lib/"* lib/
+	mv "$I-$KIEKER_VERSION/bin/"* bin/
+	rm -rf "$I-$KIEKER_VERSION"
 done
 
 cd ..
-tar -cvzpf "${BUILD_PATH}-${VERSION}.tgz" "${PACKAGE_NAME}"
-zip -r "${BUILD_PATH}-${VERSION}.zip" "${PACKAGE_NAME}"
+tar -cvzpf "${BUILD_PATH}-${KIEKER_VERSION}.tgz" "${PACKAGE_NAME}"
+zip -r "${BUILD_PATH}-${KIEKER_VERSION}.zip" "${PACKAGE_NAME}"
 
 rm -rf "${BUILD_PATH}"
 

--- a/bin/dev/assemble-tools.sh
+++ b/bin/dev/assemble-tools.sh
@@ -3,13 +3,13 @@
 BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
 BASE_DIR="${BIN_DIR}/../.."
-VERSION="2.0.0-SNAPSHOT"
+KIEKER_VERSION="2.0.0-SNAPSHOT"
 
 "${BIN_DIR}/assemble-tools-architecture-recovery.sh"
 
 mkdir "${BASE_DIR}/build/tools"
 for I in behavior-analysis collector convert-logging-timestamp log-replayer rewrite-log-entries ; do
-	cp "${BASE_DIR}/tools/$I/build/distributions/$I-${VERSION}.zip" "${BASE_DIR}/build/tools"
+	cp "${BASE_DIR}/tools/$I/build/distributions/$I-${KIEKER_VERSION}.zip" "${BASE_DIR}/build/tools"
 done
 
 "${BIN_DIR}/assemble-tools-trace-analysis.sh"


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Replace `KIEKER_VERSION` also in the bash scripts to get the release check running again (otherwise, files are not found in `bin/dev/assemble-tools.sh`
- Contribution 2 Don't publish to maven local in the distribution build (undo https://github.com/kieker-monitoring/kieker/commit/1909f12a7e5407d8688179c4bfdacfee554faa0e) to avoid the following error:
```
* What went wrong:
Execution failed for task ':publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Invalid publication 'mavenJava': artifact file does not exist: '/home/jenkins-agent/workspace/kieker-release-check_main/build/libs/kieker-99.9-javadoc.jar.asc'
```
After these contributions, the release check build works again (https://build.se.informatik.uni-kiel.de/view/Kieker/job/kieker-release-check/job/KIEKER-1986-Kieker-Release-Check-Build-Fails/)

## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
