### PR TITLE
Kieker 1987 update only libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   aspectJarConfig "org.aspectj:aspectjweaver:${aspectjVersion}"
   aspectJarConfig "com.rabbitmq:amqp-client:5.21.0"
 
-  bytebuddyJarConfig "net.bytebuddy:byte-buddy:1.14.17"
+  bytebuddyJarConfig "net.bytebuddy:byte-buddy:1.14.18"
   bytebuddyJarConfig "commons-io:commons-io:2.16.0"
 }
 

--- a/monitoring/bytebuddy/build.gradle
+++ b/monitoring/bytebuddy/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation project(':common')
 	implementation project(':monitoring:core')
 
-	implementation 'net.bytebuddy:byte-buddy:1.14.17'
+	implementation 'net.bytebuddy:byte-buddy:1.14.18'
 
 	// testing
 	testImplementation "org.hamcrest:hamcrest:$libHamcrestVersion"

--- a/monitoring/core/build.gradle
+++ b/monitoring/core/build.gradle
@@ -91,8 +91,8 @@ dependencies {
 	// this project depends on the tests of common, e.g., it requires the class AbstractKiekerTest
 	testImplementation project (path: ':common', configuration: 'testArchives')
 
-	testImplementation "org.eclipse.jetty:jetty-server:12.0.9"
-	testImplementation "org.eclipse.jetty:jetty-webapp:11.0.22"
+	testImplementation "org.eclipse.jetty:jetty-server:12.0.11"
+	testImplementation "org.eclipse.jetty.ee10:jetty-ee10-webapp:12.0.11"
 	testImplementation "org.eclipse.jetty:apache-jsp:11.0.22"
 
 	testImplementation "commons-io:commons-io:2.16.0"

--- a/monitoring/core/build.gradle
+++ b/monitoring/core/build.gradle
@@ -66,19 +66,14 @@ dependencies {
 	implementation "org.glassfish.jersey.core:jersey-common:3.1.8"
 	implementation "org.glassfish.jersey.core:jersey-client:3.1.7"
 
-	// https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
 	implementation "javax.servlet:javax.servlet-api:4.0.1"
-	// https://mvnrepository.com/artifact/javax.jms/javax.jms-api
 	implementation "javax.jms:javax.jms-api:2.0.1"
 
 	implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.2"
 	implementation "javax.jws:javax.jws-api:1.1"
 
-	// influxdb
-	// https://mvnrepository.com/artifact/org.influxdb/influxdb-java
 	implementation "org.influxdb:influxdb-java:2.24"
 
-	// https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
 	implementation "com.squareup.okhttp3:okhttp:4.12.0"
 
 	// testing


### PR DESCRIPTION
# Pull Request

This PR should supersede https://github.com/kieker-monitoring/kieker/pull/587. We shouldn't have a bunch of PRs, all containing the gradlew update, and being blocked by it - instead, I'll create the changes in new PRs and one PR for the Gradle update (and than we can debug the BuildScript-jacoco-problem there). 

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Update ByteBuddy to 1.14.18
- Contribution 2 Update Jersey to 12.0.11


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
