### PR TITLE
Remove duplicate jackson-core and jackson in tools dependencies

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,6 @@ project.artifacts {
 
 dependencies {
 	implementation "com.fasterxml.jackson.core:jackson-databind:2.17.2"
-	implementation "com.fasterxml.jackson.core:jackson-core:2.18.1"
 	implementation "ch.qos.logback:logback-classic:$libLogbackVersion"
 	implementation "org.slf4j:slf4j-api:$libSlf4jApiVersion"
 }

--- a/tools/behavior-analysis/build.gradle
+++ b/tools/behavior-analysis/build.gradle
@@ -20,8 +20,6 @@ dependencies {
 
 	implementation "com.beust:jcommander:${jcommanderVersion}"
 	implementation "com.edwardraff:JSAT:0.0.9"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.17.2"
-	implementation "com.fasterxml.jackson.core:jackson-core:2.18.1"
 
 	testImplementation project (path: ':common', configuration: 'testArchives')
 	testImplementation project (path: ':tools', configuration: 'testArchives')

--- a/tools/cmi/build.gradle
+++ b/tools/cmi/build.gradle
@@ -20,8 +20,6 @@ dependencies {
 
 	implementation "com.beust:jcommander:${jcommanderVersion}"
 	implementation "com.edwardraff:JSAT:0.0.9"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.17.2"
-	implementation "com.fasterxml.jackson.core:jackson-core:2.18.1"
 
 	testImplementation project (path: ':common', configuration: 'testArchives')
 	testImplementation project (path: ':tools', configuration: 'testArchives')


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 jackson-core is sometimes added as separate dependency; thats not necessary, since it is included as the transitive dependency of jackson-databind
- Contribution 2 Remove jackson dependency from tools completely, since its already in common which is included by the tools


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
