### PR TITLE
Gh 5 fix jacoco

### DIFF
--- a/tools/otel-transformer/build.gradle
+++ b/tools/otel-transformer/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 	implementation 'de.cau.cs.se.teetime:teetime:3.1.1'
 	implementation 'org.slf4j:slf4j-api:2.0.+'
-	implementation 'ch.qos.logback:logback-classic:1.5.15'
+	implementation 'ch.qos.logback:logback-classic:1.5.16'
 	implementation "com.beust:jcommander:${jcommanderVersion}"
 
 	implementation "io.opentelemetry:opentelemetry-api:${opentelemetryJavaVersion}"

--- a/tools/sar/build.gradle
+++ b/tools/sar/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 	implementation "ch.qos.logback:logback-classic:1.5.16"
 	implementation "ch.qos.logback:logback-core:1.5.15"
-	implementation "ch.qos.logback:logback-access:1.5.12"
+	implementation "ch.qos.logback:logback-access:1.5.16"
 
 	implementation "org.csveed:csveed:0.8.2"
 

--- a/tools/sar/build.gradle
+++ b/tools/sar/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation "com.sun.xml.bind:jaxb-impl:4.0.5"
 	implementation "org.apache.commons:commons-compress:1.27.1"
 
-	implementation "ch.qos.logback:logback-classic:1.5.12"
+	implementation "ch.qos.logback:logback-classic:1.5.16"
 	implementation "ch.qos.logback:logback-core:1.5.15"
 	implementation "ch.qos.logback:logback-access:1.5.12"
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Fixing unstable build

TL;DR: logback packages (logback-core, logback-classic, logback-access) have to be updated all together.

From my tests, unstable build started to appear from [commit ``c1a70ed``](https://github.com/kieker-monitoring/kieker/commit/c1a70edd91b5b7e81b3ed90fba8f6a6c794ceecf), which updates logback-core from 1.5.12 to 1.5.15.

In detail, we had logback-classic 1.5.12 that requires ``ch/qos/logback/core/boolex/JaninoEventEvaluatorBase``, which is already [removed in logback-core 1.5.15](https://github.com/qos-ch/logback/commit/2cb6d520df7592ef1c3a198f1b5df3c10c93e183).

```
Executed test testCaseInsensitive() [kieker.tools.sar.signature.processor.MapBasedSignatureProcessorTest] with result: FAILURE

MapBasedSignatureProcessorTest > testCaseInsensitive() FAILED
    java.lang.NoClassDefFoundError: ch/qos/logback/core/boolex/JaninoEventEvaluatorBase
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:151)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:823)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:721)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:644)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at ch.qos.logback.classic.model.processor.LogbackClassicDefaultNestedComponentRules.addDefaultNestedComponentRegistryRules(LogbackClassicDefaultNestedComponentRules.java:53)
        at ch.qos.logback.classic.joran.JoranConfigurator.addDefaultNestedComponentRegistryRules(JoranConfigurator.java:77)
        at ch.qos.logback.core.joran.GenericXMLConfigurator.buildModelInterpretationContext(GenericXMLConfigurator.java:156)
        at ch.qos.logback.core.joran.JoranConfiguratorBase.buildModelInterpretationContext(JoranConfiguratorBase.java:115)
        at ch.qos.logback.classic.joran.JoranConfigurator.buildModelInterpretationContext(JoranConfigurator.java:87)
        at ch.qos.logback.core.joran.GenericXMLConfigurator.processModel(GenericXMLConfigurator.java:211)
        at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:178)
        at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:123)
        at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:66)
        at ch.qos.logback.classic.util.DefaultJoranConfigurator.configureByResource(DefaultJoranConfigurator.java:68)
        at ch.qos.logback.classic.util.DefaultJoranConfigurator.configure(DefaultJoranConfigurator.java:35)
        at ch.qos.logback.classic.util.ContextInitializer.invokeConfigure(ContextInitializer.java:128)
        at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:103)
        at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:66)
        at ch.qos.logback.classic.spi.LogbackServiceProvider.initializeLoggerContext(LogbackServiceProvider.java:52)
        at ch.qos.logback.classic.spi.LogbackServiceProvider.initialize(LogbackServiceProvider.java:41)
        at org.slf4j.LoggerFactory.bind(LoggerFactory.java:199)
        at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:186)
        at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:496)
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:482)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:431)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:457)
        at kieker.tools.sar.signature.processor.MapBasedSignatureProcessor.<init>(MapBasedSignatureProcessor.java:39)
        at kieker.tools.sar.signature.processor.MapBasedSignatureProcessorTest.testCaseInsensitive(MapBasedSignatureProcessorTest.java:81)

        Caused by:
        java.lang.ClassNotFoundException: ch.qos.logback.core.boolex.JaninoEventEvaluatorBase
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:604)
            at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
            ... 33 more
```