### PR TITLE
Migrate to OSSRH staging API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
             unstash 'jarArtifacts'
             withCredentials([
               usernamePassword(
-                credentialsId: 'OSSRH-Token',
+                credentialsId: 'Central-Portal-Token',
                 usernameVariable: 'kiekerMavenUser', 
                 passwordVariable: 'kiekerMavenPassword'
               )
@@ -302,7 +302,7 @@ pipeline {
             unstash 'jarArtifacts'
             withCredentials([
               usernamePassword(
-                credentialsId: 'OSSRH-Token', 
+                credentialsId: 'Central-Portal-Token',
                 usernameVariable: 'kiekerMavenUser', 
                 passwordVariable: 'kiekerMavenPassword'
               ),
@@ -318,6 +318,14 @@ pipeline {
                 variable: 'KEY_ID')
               ]) {
               sh './gradlew signMavenJavaPublication publish -Psigning.secretKeyRingFile=${KEY_FILE} -Psigning.password=${PASSPHRASE} -Psigning.keyId=${KEY_ID}'
+            }
+            withCredentials([
+              string(
+                credentialsId: 'Central-Portal-Token_base64',
+                variable: 'CENTRAL_PORTAL_TOKEN_BASE64'
+              )
+              ]) {
+              sh 'curl -H "Authorization: Bearer ${CENTRAL_PORTAL_TOKEN_BASE64}" -i -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/net.kieker-monitoring'
             }
       }
       

--- a/analysis/build.gradle
+++ b/analysis/build.gradle
@@ -99,8 +99,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,10 @@ allprojects {
   repositories {    // must be above subprojects {}
     mavenLocal()
     mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven {
+        name = 'ossrh-staging-api'
+        url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+    }
   }
 }
 
@@ -1263,8 +1266,8 @@ publishing {
       //def releasesRepoUrl = "/tmp/myRepo/releases"
       //def snapshotsRepoUrl = "/tmp/myRepo/snapshots"
       // Maven central:
-      def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-      def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+      def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+      def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
       url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
     }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -55,8 +55,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/examples/analysis/trace-analysis/build.gradle
+++ b/examples/analysis/trace-analysis/build.gradle
@@ -6,7 +6,7 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/adaptive-monitoring/build.gradle
+++ b/examples/monitoring/adaptive-monitoring/build.gradle
@@ -5,7 +5,7 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/custom-timesource/build.gradle
+++ b/examples/monitoring/custom-timesource/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 repositories {
 	mavenLocal()
 	mavenCentral()
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/probe-aspectj/build.gradle
+++ b/examples/monitoring/probe-aspectj/build.gradle
@@ -5,7 +5,7 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/probe-manual-tcp/build.gradle
+++ b/examples/monitoring/probe-manual-tcp/build.gradle
@@ -5,7 +5,7 @@ plugins {
 repositories {
 	mavenLocal()
         mavenCentral() 
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/probe-manual/build.gradle
+++ b/examples/monitoring/probe-manual/build.gradle
@@ -5,7 +5,7 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/probe-spring/build.gradle
+++ b/examples/monitoring/probe-spring/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = 11
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/examples/monitoring/sampler-jvm/build.gradle
+++ b/examples/monitoring/sampler-jvm/build.gradle
@@ -5,7 +5,7 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral() 
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 dependencies {

--- a/extension-cassandra/build.gradle
+++ b/extension-cassandra/build.gradle
@@ -11,7 +11,7 @@ repositories {
 	// You can declare any Maven/Ivy/file repository here.
 	mavenCentral()
 	maven {
-		url 'https://oss.sonatype.org/content/repositories/snapshots/'
+		url 'https://central.sonatype.com/repository/maven-snapshots/'
 	}
 }
 

--- a/extension-kafka/build.gradle
+++ b/extension-kafka/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	// Use mavenCentral for resolving your dependencies.
 	// You can declare any Maven/Ivy/file repository here.
 	mavenCentral()
-	maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+	maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
 }
 
 dependencies {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -57,8 +57,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/monitoring/aspectj/build.gradle
+++ b/monitoring/aspectj/build.gradle
@@ -129,8 +129,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/monitoring/core/build.gradle
+++ b/monitoring/core/build.gradle
@@ -128,8 +128,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/monitoring/disl/build.gradle
+++ b/monitoring/disl/build.gradle
@@ -53,8 +53,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/monitoring/spring/build.gradle
+++ b/monitoring/spring/build.gradle
@@ -104,8 +104,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -75,8 +75,8 @@ publishing {
 			}
 
 			// Maven central:
-			def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-			def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+			def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+			def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
 
 			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 		}

--- a/tools/fxca/build.gradle
+++ b/tools/fxca/build.gradle
@@ -12,7 +12,7 @@ distZip.enabled=true
 
 repositories {
 	mavenCentral()
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 	maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 }
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request replaces the old OSSRH token with the new Central Portal Token.
- Since we are using the Staging API, we need the curl POST commandline for publication (not for SNAPSHOT uploads). See [Line 328 of Jenkinsfile](https://github.com/kieker-monitoring/kieker/blob/41f7071c2f49db375e475285cb9239cd4db2785a/Jenkinsfile#L328)
