### PR TITLE
Check Timestamp set as false by default

### DIFF
--- a/monitoring/core/test/kieker/test/monitoring/junit/core/configuration/TestConfigurationFactoryMethods.java
+++ b/monitoring/core/test/kieker/test/monitoring/junit/core/configuration/TestConfigurationFactoryMethods.java
@@ -142,7 +142,7 @@ public class TestConfigurationFactoryMethods extends kieker.test.common.junit.Ab
 		Assert.assertEquals(false, configuration.getBooleanProperty(ConfigurationConstants.ACTIVATE_JMX));
 		// Writer controller
 		Assert.assertEquals(true, configuration.getBooleanProperty(ConfigurationConstants.META_DATA));
-		Assert.assertEquals(true, configuration.getBooleanProperty(ConfigurationConstants.AUTO_SET_LOGGINGTSTAMP));
+		Assert.assertEquals(false, configuration.getBooleanProperty(ConfigurationConstants.AUTO_SET_LOGGINGTSTAMP));
 		Assert.assertThat(configuration.getStringProperty(ConfigurationConstants.WRITER_CLASSNAME),
 				CoreMatchers.is(FileWriter.class.getName()));
 		// TimeSource controller


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Modified `testCreationDefaultConfiguration()` to reflect new default creation routine.