### PR TITLE
Adaptation of Kieker to the JPMS

### DIFF
--- a/analysis/build.gradle
+++ b/analysis/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	implementation "ch.qos.logback:logback-classic:$libLogbackVersion"
 	implementation "org.slf4j:slf4j-api:$libSlf4jApiVersion"
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
+
 
 	api "javax.xml.bind:jaxb-api:2.3.1"
 
@@ -120,4 +123,8 @@ eclipse {
 		}
 		containsTestFixtures = true
 	}
+}
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED"]
 }

--- a/analysis/src/module-info.java
+++ b/analysis/src/module-info.java
@@ -1,0 +1,106 @@
+/**
+ * This module offers the packages {@code kieker.analysis.analysisComponent},
+ * {@code kieker.analysis.annotation}, {@code kieker.analysis.architecture},
+ * {@code kieker.analysis.behaviour}, {@code kieker.analysis.code},
+ * {@code kieker.analysis.exception}, {@code kieker.analysis.generic},
+ * {@code kieker.analysis.metrics}, {@code kieker.analysis.plugin},
+ * {@code kieker.analysis.repository},
+ * {@code kieker.analysis.util} and all the subpackages.
+ * <p>
+ * This module is the code basis for the analysis functions:
+ * <ul>
+ *   <li>trace reconstruction and visualization</li>
+ *   <li>anomaly detection</li>
+ *   <li>architecture discovery and visualization</li>
+ * </ul>
+ */
+module kieker.analysis {
+
+    //Provided Packages
+    exports kieker.analysis.behavior;
+    exports kieker.analysis.behavior.acceptance.matcher;
+    exports kieker.analysis.behavior.clustering;
+    exports kieker.analysis.behavior.signature.processor;
+    exports kieker.analysis.behavior.model;
+    exports kieker.analysis.behavior.events;
+    exports kieker.analysis.metrics.graph.entropy;
+    exports kieker.analysis.plugin;
+    exports kieker.analysis.plugin.filter;
+    exports kieker.analysis.plugin.filter.flow;
+    exports kieker.analysis.plugin.filter.record;
+    exports kieker.analysis.plugin.filter.select;
+    exports kieker.analysis.plugin.reader;
+    exports kieker.analysis.plugin.reader.filesystem;
+    exports kieker.analysis.plugin.reader.newio;
+    exports kieker.analysis.plugin.annotation;
+    exports kieker.analysis.plugin.trace;
+    exports kieker.analysis.repository;
+    exports kieker.analysis.repository.annotation;
+    exports kieker.analysis.analysisComponent;
+    exports kieker.analysis.statistics;
+    exports kieker.analysis.statistics.calculating;
+    exports kieker.analysis.util;
+    exports kieker.analysis.util.stage;
+    exports kieker.analysis.util.stage.trigger;
+    exports kieker.analysis.architecture;
+    exports kieker.analysis.architecture.dependency;
+    exports kieker.analysis.architecture.trace;
+    exports kieker.analysis.architecture.trace.reconstruction;
+    exports kieker.analysis.architecture.trace.execution;
+    exports kieker.analysis.architecture.trace.sink;
+    exports kieker.analysis.architecture.trace.flow;
+    exports kieker.analysis.architecture.recovery;
+    exports kieker.analysis.architecture.recovery.assembler;
+    exports kieker.analysis.architecture.recovery.events;
+    exports kieker.analysis.architecture.recovery.signature;
+    exports kieker.analysis.architecture.repository;
+    exports kieker.analysis.generic;
+    exports kieker.analysis.generic.sink;
+    exports kieker.analysis.generic.sink.graph;
+    exports kieker.analysis.generic.sink.graph.dot;
+    exports kieker.analysis.generic.sink.graph.dot.attributes;
+    exports kieker.analysis.generic.sink.graph.graphml;
+    exports kieker.analysis.generic.source;
+    exports kieker.analysis.generic.source.rest;
+    exports kieker.analysis.generic.source.file;
+    exports kieker.analysis.generic.source.tcp;
+    exports kieker.analysis.generic.source.rewriter;
+    exports kieker.analysis.generic.data;
+    exports kieker.analysis.generic.time;
+    exports kieker.analysis.generic.graph;
+    exports kieker.analysis.generic.graph.clustering;
+    exports kieker.analysis.generic.graph.selector;
+    exports kieker.analysis.generic.clustering;
+    exports kieker.analysis.generic.clustering.optics;
+    exports kieker.analysis.generic.clustering.mtree;
+    exports kieker.analysis.generic.clustering.mtree.utils;
+    exports kieker.analysis.code;
+    exports kieker.analysis.code.data;
+    exports kieker.analysis.exception;
+    exports kieker.analysis;
+
+
+    // Kieker dependencies
+    requires kieker.model;
+    requires kieker.common;
+
+    // Java Dependencies
+    requires java.sql;
+    requires java.management;
+    requires java.naming;
+    requires java.xml;
+    requires java.xml.bind;
+
+    // Third-Party Dependencies
+    requires com.google.common;
+    requires org.apache.commons.compress;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.eclipse.emf.ecore.xmi;
+    requires org.slf4j;
+    requires org.tukaani.xz;
+    requires org.yaml.snakeyaml;
+    requires kieker.monitoring.core;
+
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -920,6 +920,7 @@ task springJar(type: Jar, dependsOn: springSubprojects.tasks["build"], group: "b
 
 task sourcesJar(type: Jar, dependsOn: classes) {
   archiveClassifier = 'sources'
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   from mainSubprojects.collect { project -> project.sourceSets.main.allJava }
 }
 

--- a/common/src/module-info.java
+++ b/common/src/module-info.java
@@ -1,0 +1,53 @@
+/**
+ * This module offers the packages {@code kieker.common.configuration},
+ * {@code kieker.common.exception}, {@code kieker.common.namedRecordPipe},
+ * {@code kieker.common.record}, {@code kieker.common.registry},
+ * {@code kieker.common.util} and all the subpackages.
+ *<p>
+ * This module is used to provide a common code base, used by various other modules and packages.
+ * For example, various records are defined here, which are used and created by other parts,
+ * such as multiple classes within in the monitoring or analysis modules.
+ *
+ **/
+module kieker.common {
+    //Provided Packages
+    exports kieker.common.configuration;
+    exports kieker.common.exception;
+    exports kieker.common.namedRecordPipe;
+    exports kieker.common.record;
+    exports kieker.common.record.misc;
+    exports kieker.common.record.io;
+    exports kieker.common.record.factory;
+    exports kieker.common.record.database;
+    exports kieker.common.record.session;
+    exports kieker.common.record.controlflow;
+    exports kieker.common.record.flow;
+    exports kieker.common.record.flow.trace;
+    exports kieker.common.record.flow.trace.operation;
+    exports kieker.common.record.flow.trace.operation.constructor;
+    exports kieker.common.record.flow.trace.operation.constructor.object;
+    exports kieker.common.record.flow.trace.operation.object;
+    exports kieker.common.record.flow.trace.concurrency;
+    exports kieker.common.record.flow.trace.concurrency.monitor;
+    exports kieker.common.record.flow.thread;
+    exports kieker.common.record.jvm;
+    exports kieker.common.record.remotecontrol;
+    exports kieker.common.record.system;
+    exports kieker.common.registry;
+    exports kieker.common.registry.writer;
+    exports kieker.common.registry.reader;
+    exports kieker.common.util;
+    exports kieker.common.util.classpath;
+    exports kieker.common.util.dataformat;
+    exports kieker.common.util.filesystem;
+    exports kieker.common.util.map;
+    exports kieker.common.util.signature;
+    exports kieker.common.util.thread;
+
+    //Java Dependencies
+    requires java.logging;
+
+    //Third-Party Dependencies
+    requires com.fasterxml.jackson.databind;
+    requires org.slf4j;
+}

--- a/common/src/module-info.java
+++ b/common/src/module-info.java
@@ -44,6 +44,10 @@ module kieker.common {
     exports kieker.common.util.signature;
     exports kieker.common.util.thread;
 
+    //Services
+    uses kieker.common.record.factory.IRecordFactoryProvider;
+
+
     //Java Dependencies
     requires java.logging;
 

--- a/extension-cassandra/build.gradle
+++ b/extension-cassandra/build.gradle
@@ -23,3 +23,7 @@ dependencies {
 	implementation "com.datastax.cassandra:cassandra-driver-core:4.0.0"
 
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.extension.cassandra=ALL-UNNAMED"]
+}

--- a/extension-cassandra/src/module-info.java
+++ b/extension-cassandra/src/module-info.java
@@ -1,0 +1,12 @@
+/**
+ * The Cassandra extension lets Kieker persist its monitoring,
+ * trace and log data into an Apache Cassandra database
+ */
+module kieker.extension.cassandra {
+    //Kieker dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+
+    //Third Party dependencies
+    requires org.slf4j;
+}

--- a/extension-kafka/build.gradle
+++ b/extension-kafka/build.gradle
@@ -26,3 +26,8 @@ dependencies {
 	// Use JUnit test framework
 	// testImplementation "junit:junit:4.12"
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.extension.kafka=ALL-UNNAMED"]
+}
+

--- a/extension-kafka/src/module-info.java
+++ b/extension-kafka/src/module-info.java
@@ -1,0 +1,10 @@
+/**
+ * The Kafka extension lets Kieker read and write monitoring records
+ * to and from Apache kafka topics.
+ */
+module kieker.extension.kafka {
+    //Kieker dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.monitoring.core;
+}

--- a/model/src/module-info.java
+++ b/model/src/module-info.java
@@ -1,0 +1,47 @@
+/**
+ * This module offers the packages {@code kieker.model.repository},
+ * {@code kieker.model.system.model}, {@code kieker.system.model.util} and
+ * {@code kieker.system.model.exceptions}
+ *
+ * Model holds and manages the monitoring data model that represents the
+ * observed runtime behavior of a software system.
+ **/
+module kieker.model {
+    //Provided Packages
+    exports kieker.model.repository;
+    exports kieker.model.system.model;
+    exports kieker.model.system.model.util;
+    exports kieker.model.system.model.exceptions;
+    exports kieker.model.collection;
+    exports kieker.model.collection.util;
+    exports kieker.model.collection.impl;
+    exports kieker.model.analysismodel;
+    exports kieker.model.analysismodel.assembly;
+    exports kieker.model.analysismodel.assembly.util;
+    exports kieker.model.analysismodel.assembly.impl;
+    exports kieker.model.analysismodel.deployment;
+    exports kieker.model.analysismodel.deployment.util;
+    exports kieker.model.analysismodel.deployment.impl;
+    exports kieker.model.analysismodel.execution;
+    exports kieker.model.analysismodel.execution.util;
+    exports kieker.model.analysismodel.execution.impl;
+    exports kieker.model.analysismodel.impl;
+    exports kieker.model.analysismodel.source;
+    exports kieker.model.analysismodel.source.util;
+    exports kieker.model.analysismodel.source.impl;
+    exports kieker.model.analysismodel.statistics;
+    exports kieker.model.analysismodel.statistics.util;
+    exports kieker.model.analysismodel.statistics.impl;
+    exports kieker.model.analysismodel.trace;
+    exports kieker.model.analysismodel.trace.util;
+    exports kieker.model.analysismodel.trace.impl;
+    exports kieker.model.analysismodel.type;
+    exports kieker.model.analysismodel.type.util;
+    exports kieker.model.analysismodel.type.impl;
+    //Kieker Dependencies
+    requires kieker.common;
+
+    //Third-Party Dependencies -- from src-gen
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+}

--- a/monitoring/aspectj/build.gradle
+++ b/monitoring/aspectj/build.gradle
@@ -57,7 +57,6 @@ dependencies {
 	implementation project(':monitoring:core')
 
 	aspectJCompileTime "org.aspectj:aspectjtools:1.9.25.1"
-	implementation "org.aspectj:aspectjrt:$aspectjVersion"
 	implementation "org.aspectj:aspectjweaver:$aspectjVersion"	// for our custom AspectJ weaver (class: AspectJLoader)
 
 	implementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
@@ -209,4 +208,8 @@ eclipse {
 			}
 		}
 	}
+}
+
+tasks.named("compileJava") {
+    options.compilerArgs += ['--add-reads', "kieker.monitoring.aspectj=ALL-UNNAMED"]
 }

--- a/monitoring/aspectj/src/module-info.java
+++ b/monitoring/aspectj/src/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * This module implements a java agent that performs monitoring
+ * via Aspect-Oriented Programming (AOP).
+ */
+module kieker.monitoring.aspectj {
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+
+    //Java Dependency
+    requires java.sql;
+    requires java.instrument;
+
+    //Third Party Dependencies
+    requires org.aspectj.weaver;
+    requires org.slf4j;
+    requires jakarta.ws.rs;
+}

--- a/monitoring/bytebuddy/src/module-info.java
+++ b/monitoring/bytebuddy/src/module-info.java
@@ -1,0 +1,17 @@
+/**
+ * This module implements a Java agent that performs
+ * code generation and manipulation with the help of bytebuddy.
+ */
+module kieker.monitoring.bytebuddy
+{
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+
+    //Java Dependencies
+    requires java.instrument;
+
+    //Third Party Dependencies
+    requires net.bytebuddy;
+    requires org.slf4j;
+}

--- a/monitoring/core/build.gradle
+++ b/monitoring/core/build.gradle
@@ -150,3 +150,7 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.monitoring.core=ALL-UNNAMED"]
+}

--- a/monitoring/core/src/module-info.java
+++ b/monitoring/core/src/module-info.java
@@ -1,0 +1,44 @@
+/**
+ * This module offers the packages {@code kieker.monitoring.probe},
+ * {@code kieker.monitoring.sampler}, {@code kieker.monitoring.util},
+ * {@code kieker.monitoring.core}, {@code kieker.monitoring.writer},
+ * {@code kieker.monitoring.timer} and most of their subpackages.
+ *
+ * This module is responsible for the instrumentation of applications,
+ * generates runtime data in form of records (--> Analysis) and
+ * provides an API for implementing your own writers.
+ */
+module kieker.monitoring.core {
+    //Provided Packages
+    exports kieker.monitoring;
+    exports kieker.monitoring.probe;
+    exports kieker.monitoring.probe.utilities;
+    exports kieker.monitoring.sampler.oshi;
+    exports kieker.monitoring.util;
+    exports kieker.monitoring.core.registry;
+    exports kieker.monitoring.core.controller;
+    exports kieker.monitoring.core.sampler;
+    exports kieker.monitoring.core.configuration;
+    exports kieker.monitoring.writer;
+    exports kieker.monitoring.writer.filesystem;
+    exports kieker.monitoring.writer.tcp;
+    exports kieker.monitoring.writer.compression;
+    exports kieker.monitoring.writer.raw;
+    exports kieker.monitoring.timer;
+
+    //Kieker Dependencies
+    requires kieker.common;
+
+    //Java Dependencies
+    requires java.management;
+    requires java.naming;
+    requires java.xml;
+
+    //Third Party Dependencies
+    requires org.apache.commons.compress;
+    requires org.apache.commons.io;
+    requires org.slf4j;
+    requires com.github.oshi;
+    requires org.tukaani.xz;
+
+}

--- a/monitoring/disl/build.gradle
+++ b/monitoring/disl/build.gradle
@@ -80,3 +80,7 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.monitoring.disl=ALL-UNNAMED"]
+}

--- a/monitoring/disl/src/module-info.java
+++ b/monitoring/disl/src/module-info.java
@@ -1,0 +1,14 @@
+/**
+ * This module implements a java agent that performs monitoring
+ * with the help of DiSL, which is inspired by Aspect-Oriented-
+ * Programming (AOP).
+ */
+module kieker.monitoring.disl {
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+
+    //Third Party Dependencies
+    requires org.objectweb.asm;
+    requires org.objectweb.asm.tree;
+}

--- a/monitoring/javassist/src/module-info.java
+++ b/monitoring/javassist/src/module-info.java
@@ -1,0 +1,16 @@
+/**
+ * This module extends Kieker’s monitoring abilities by leveraging
+ * Javassist for dynamic bytecode manipulation and the Java
+ * Instrumentation API for integrating those changes at runtime.
+ */
+module kieker.monitoring.javassist {
+
+    //Kieker Dependencies
+    requires kieker.monitoring.core;
+
+    //Java Dependencies
+    requires java.instrument;
+
+    //Third-Party Dependencies
+    requires org.javassist;
+}

--- a/monitoring/spring/build.gradle
+++ b/monitoring/spring/build.gradle
@@ -131,3 +131,7 @@ eclipse {
 		}
 	}
 }
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.monitoring.spring=ALL-UNNAMED"]
+}
+

--- a/monitoring/spring/src/module-info.java
+++ b/monitoring/spring/src/module-info.java
@@ -1,0 +1,16 @@
+/**
+ * This module contains interceptors and filters for monitoring Spring-based
+ * applications. It captures execution of Spring-based applications and forwards
+ * the collected data to the kieker monitoring infrastructure.
+ */
+module kieker.monitoring.spring {
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+    requires spring.aop;
+    requires spring.context;
+    requires spring.web;
+}

--- a/tools/allen-upper-limit/build.gradle
+++ b/tools/allen-upper-limit/build.gradle
@@ -54,3 +54,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.aul=ALL-UNNAMED",
+	]
+}

--- a/tools/allen-upper-limit/src/module-info.java
+++ b/tools/allen-upper-limit/src/module-info.java
@@ -1,0 +1,22 @@
+/**
+ * This module contains an architecture analysis utility that computes
+ * the “Allen upper limit” over a model or a generated test graph. In practice,
+ * it evaluates upper bounds for temporal/ordering relations (based on Allen’s
+ * interval reasoning) or equivalent relation constraints within an architecture/network model.
+ * This helps bound the maximum number of feasible relations/edges and assess structural or
+ * timing constraints inferred from execution data.
+ */
+module kieker.tools.aul {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party-Dependencies
+    requires com.google.common;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+}

--- a/tools/behavior-analysis/build.gradle
+++ b/tools/behavior-analysis/build.gradle
@@ -44,3 +44,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.behavior.analysis=ALL-UNNAMED",
+	]
+}

--- a/tools/behavior-analysis/src/module-info.java
+++ b/tools/behavior-analysis/src/module-info.java
@@ -1,0 +1,17 @@
+/**
+ * This module is used to mine and analyze runtime behavior from execution
+ * traces and monitoring logs. It reconstructs user/session flows and derives
+ * behavior models (e.g., Markov chains or branching user-behavior graphs) to
+ * characterize how a system is actually used.
+ */
+module kieker.tools.behavior.analysis {
+
+    //Kieker Dependencies
+    requires kieker.tools;
+    requires kieker.analysis;
+    requires kieker.common;
+
+    //Third-Party Dependencies
+    requires org.slf4j;
+    requires com.google.common;
+}

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -97,3 +97,9 @@ eclipse {
 		containsTestFixtures = true
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED"
+	]
+}

--- a/tools/cmi/build.gradle
+++ b/tools/cmi/build.gradle
@@ -44,3 +44,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.cmi=ALL-UNNAMED",
+	]
+}

--- a/tools/cmi/src/module-info.java
+++ b/tools/cmi/src/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * This module performs continuous model inference (CMI) from Kieker
+ * monitoring data, reconstructing and continuously updating
+ * component/service interaction and operation-call models
+ * (e.g., dependency/communication graphs) for architecture discovery,
+ * visualization, and drift/change analysis.
+ */
+module kieker.tools.cmi {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+}

--- a/tools/collector/build.gradle
+++ b/tools/collector/build.gradle
@@ -43,3 +43,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.collector=ALL-UNNAMED",
+	]
+}

--- a/tools/collector/src/module-info.java
+++ b/tools/collector/src/module-info.java
@@ -1,0 +1,13 @@
+/**
+ * This module acts as a central receiver for Kieker monitoring data,
+ * collecting records from distributed sources and persisting or
+ * forwarding them to standardized Kieker logs or downstream analysis
+ * pipelines for centralized monitoring.
+ */
+module kieker.tools.collector {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.tools;
+}

--- a/tools/convert-logging-timestamp/build.gradle
+++ b/tools/convert-logging-timestamp/build.gradle
@@ -40,3 +40,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.logging.timestamp.converter=ALL-UNNAMED",
+	]
+}

--- a/tools/convert-logging-timestamp/src/module-info.java
+++ b/tools/convert-logging-timestamp/src/module-info.java
@@ -1,0 +1,15 @@
+/**
+ * This module provides a command-line utility to convert Kieker logging
+ * timestamps (nanoseconds since the Unix epoch) into human-readable
+ * date/time strings, printing both UTC and local-time representations
+ * for quick inspection, troubleshooting, and reporting.
+ */
+module kieker.tools.logging.timestamp.converter {
+
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/dar/build.gradle
+++ b/tools/dar/build.gradle
@@ -59,3 +59,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.dar=ALL-UNNAMED",
+	]
+}

--- a/tools/dar/src/module-info.java
+++ b/tools/dar/src/module-info.java
@@ -1,0 +1,17 @@
+/**
+ * This module performs delta analysis of Kieker-derived models and logs,
+ * comparing two snapshots/baselines to detect added/removed/changed
+ * components, operations, interactions, and metric shifts, and produces
+ * reports (e.g., CSV/JSON) for architecture drift and regression assessment.
+ */
+module kieker.tools.dar {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/delta/build.gradle
+++ b/tools/delta/build.gradle
@@ -64,3 +64,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.delta=ALL-UNNAMED",
+	]
+}

--- a/tools/delta/src/module-info.java
+++ b/tools/delta/src/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * This module compares two Kieker-derived snapshots or models
+ * to compute deltas—identifying added/removed/changed components,
+ * operations, interactions, and metrics—and outputs reports for
+ * architecture drift and regression analysis.
+ */
+module kieker.tools.delta {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.tools;
+    requires kieker.tools.restructuring;
+
+    //Third-Party Dependencies
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.eclipse.emf.ecore.xmi;
+    requires org.slf4j;
+}

--- a/tools/fxca/build.gradle
+++ b/tools/fxca/build.gradle
@@ -79,3 +79,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.fxca=ALL-UNNAMED",
+	]
+}

--- a/tools/fxca/src/module-info.java
+++ b/tools/fxca/src/module-info.java
@@ -1,0 +1,21 @@
+/**
+ * This module analyzes Fortran code by processing fxtran-generated XML,
+ * producing a call table, operation definitions, and a “not-found” report
+ * to support code comprehension and downstream tooling.
+ */
+module kieker.tools.fxca {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Java Dependencies
+    requires java.xml;
+
+    //Third-Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.apache.commons.lang3;
+    requires org.slf4j;
+}

--- a/tools/log-replayer/build.gradle
+++ b/tools/log-replayer/build.gradle
@@ -42,3 +42,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.log.replayer=ALL-UNNAMED",
+	]
+}

--- a/tools/log-replayer/src/module-info.java
+++ b/tools/log-replayer/src/module-info.java
@@ -1,0 +1,17 @@
+/**
+ * This module replays Kieker monitoring logs as a live event
+ * stream—reading recorded monitoring records and emitting them
+ * with original or configurable timing—to reproduce runs, drive
+ * and validate analysis pipelines, and test integrations.
+ */
+module kieker.tools.log.replayer {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.monitoring.core;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/maa/build.gradle
+++ b/tools/maa/build.gradle
@@ -62,3 +62,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.maa=ALL-UNNAMED",
+	]
+}

--- a/tools/maa/src/module-info.java
+++ b/tools/maa/src/module-info.java
@@ -1,0 +1,19 @@
+/**
+ * This module performs model-based architecture analysis over
+ * Kieker EMF/XMI models—loading architecture snapshots, computing
+ * structural/metric evaluations and consistency checks, and exporting
+ * results (e.g., CSV/JSON) for quality assessment and reporting.
+ */
+module kieker.tools.maa {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.eclipse.emf.common;
+    requires org.slf4j;
+}

--- a/tools/mktable/build.gradle
+++ b/tools/mktable/build.gradle
@@ -55,3 +55,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.mktable=ALL-UNNAMED",
+	]
+}

--- a/tools/mktable/src/module-info.java
+++ b/tools/mktable/src/module-info.java
@@ -1,0 +1,15 @@
+/**
+ * This module generates formatted tables from Kieker analysis
+ * or experiment outputs — aggregating, filtering, and formatting
+ * metrics into report - or publication-ready CSV/Markdown/LaTeX tables.
+ */
+module kieker.tools.mktable {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/mop/build.gradle
+++ b/tools/mop/build.gradle
@@ -64,3 +64,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.mop=ALL-UNNAMED",
+	]
+}

--- a/tools/mop/src/module-info.java
+++ b/tools/mop/src/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * This module processes monitored-operation profiles: it reads and
+ * validates operation patterns/definitions, merges and filters them,
+ * and exports configuration files to drive Kieker instrumentation
+ * and downstream analyses.
+ */
+module kieker.tools.mop {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+}

--- a/tools/mt/build.gradle
+++ b/tools/mt/build.gradle
@@ -59,3 +59,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.mt=ALL-UNNAMED",
+	]
+}

--- a/tools/mt/src/module-info.java
+++ b/tools/mt/src/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * This module manipulates tabular datasets (primarily CSV) from
+ * Kieker analyses—supporting merges/joins, filtering, sorting,
+ * column derivations/renaming, text substitutions, normalization,
+ * and exporting the transformed tables for downstream reporting.
+ */
+module kieker.tools.mt {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.apache.commons.text;
+    requires org.slf4j;
+}

--- a/tools/mvis/build.gradle
+++ b/tools/mvis/build.gradle
@@ -56,3 +56,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.mvis=ALL-UNNAMED",
+	]
+}

--- a/tools/mvis/src/module-info.java
+++ b/tools/mvis/src/module-info.java
@@ -1,0 +1,21 @@
+/**
+ * This module visualizes Kieker-derived architecture/models—loading
+ * EMF/XMI models, constructing graph-based views of components and
+ * relations, and exporting visualization artifacts for documentation
+ * and analysis.
+ */
+module kieker.tools.mvis {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires com.google.common;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+}

--- a/tools/opad/build.gradle
+++ b/tools/opad/build.gradle
@@ -41,3 +41,10 @@ dependencies {
 	testImplementation project(':common').sourceSets.test.output
 	testImplementation project(':tools').sourceSets.test.output
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.opad=ALL-UNNAMED",
+	]
+}

--- a/tools/opad/src/module-info.java
+++ b/tools/opad/src/module-info.java
@@ -1,0 +1,16 @@
+/**
+ * This module performs online performance anomaly detection on
+ * operation-level time series (e.g., response times), offering
+ * pipelines/filters that learn baselines, detect deviations, and
+ * emit/store detection results for further analysis and alerting.
+ */
+module kieker.tools.opad {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+
+    //Third-Party Dependencies
+    requires org.apache.commons.lang3;
+    requires org.slf4j;
+}

--- a/tools/otel-transformer/build.gradle
+++ b/tools/otel-transformer/build.gradle
@@ -24,3 +24,10 @@ dependencies {
 	implementation "io.opentelemetry:opentelemetry-exporter-otlp:${opentelemetryJavaVersion}"
 	implementation "io.opentelemetry:opentelemetry-exporter-zipkin:${opentelemetryJavaVersion}"
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.oteltransformer=ALL-UNNAMED",
+	]
+}

--- a/tools/otel-transformer/src/module-info.java
+++ b/tools/otel-transformer/src/module-info.java
@@ -1,0 +1,24 @@
+/**
+ * This module is used to convert OpenTelemetry telemetry — primarily traces/spans
+ * (and, in some setups, metrics/logs) — into Kieker-compatible data so you can
+ * leverage Kieker’s analysis and visualization tools.
+ */
+module kieker.tools.oteltransformer {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.monitoring.core;
+    requires kieker.tools;
+
+    //Third-Party Dependencies
+    requires io.opentelemetry.api;
+    requires io.opentelemetry.context;
+    requires io.opentelemetry.exporter.otlp;
+    requires io.opentelemetry.exporter.zipkin;
+    requires io.opentelemetry.sdk;
+    requires io.opentelemetry.sdk.common;
+    requires io.opentelemetry.sdk.trace;
+    requires org.slf4j;
+}

--- a/tools/relabel/build.gradle
+++ b/tools/relabel/build.gradle
@@ -55,3 +55,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.relabel=ALL-UNNAMED",
+	]
+}

--- a/tools/relabel/src/module-info.java
+++ b/tools/relabel/src/module-info.java
@@ -1,0 +1,21 @@
+/**
+ * This module relabels identifiers in Kieker models and analysis
+ * artifacts — applying user-defined mapping rules to rename
+ * components/operations/types/hosts for normalization or anonymization —
+ * while loading/saving EMF-based models to ensure all references remain
+ * consistent for downstream tools.
+ */
+module kieker.tools.relabel {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+
+}

--- a/tools/resource-monitor/build.gradle
+++ b/tools/resource-monitor/build.gradle
@@ -37,3 +37,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.resource.monitor=ALL-UNNAMED",
+	]
+}

--- a/tools/resource-monitor/src/module-info.java
+++ b/tools/resource-monitor/src/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * This module monitors host-level system resources (CPU,
+ * memory/swap, load average, network utilization, disk I/O)
+ * at configurable intervals and duration, using Kieker’s
+ * monitoring controller and OSHI-based samplers, providing
+ * a CLI tool to start/stop sampling and emit the gathered
+ * metrics for recording and analysis.
+ */
+module kieker.tools.resource.monitor {
+
+    //Kieker Dependencies
+    requires kieker.common;
+    requires kieker.monitoring.core;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/restructuring/build.gradle
+++ b/tools/restructuring/build.gradle
@@ -67,3 +67,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.restructuring=ALL-UNNAMED",
+	]
+}

--- a/tools/restructuring/src/module-info.java
+++ b/tools/restructuring/src/module-info.java
@@ -1,0 +1,27 @@
+/**
+ * This module restructures Kieker architecture models (components
+ * and operations) via a TeeTime-based CLI pipeline—loading models,
+ * applying configurable transformations (e.g., merge, split,
+ * regroup), and exporting the refined models for downstream
+ * analysis and visualization.
+ */
+module kieker.tools.restructuring {
+
+    //Provided Packages
+    exports kieker.tools.restructuring.restructuremodel;
+
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.eclipse.emf.ecore.xmi;
+    requires org.jgrapht.core;
+    requires org.slf4j;
+}

--- a/tools/rewrite-log-entries/build.gradle
+++ b/tools/rewrite-log-entries/build.gradle
@@ -43,3 +43,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.log.rewriter=ALL-UNNAMED",
+	]
+}

--- a/tools/rewrite-log-entries/src/module-info.java
+++ b/tools/rewrite-log-entries/src/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * This module reads Kieker monitoring logs and rewrites their
+ * entries according to user-defined rules—e.g., normalizing or
+ * anonymizing attributes, correcting/retiming timestamps,
+ * remapping identifiers, and filtering records—and outputs an
+ * adjusted log for consistent downstream analysis.
+ */
+module kieker.log.rewriter {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.monitoring.core;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+    requires org.jctools.core;
+
+}

--- a/tools/runtime-analysis/src/module-info.java
+++ b/tools/runtime-analysis/src/module-info.java
@@ -1,0 +1,10 @@
+/**
+ * This module performs online analysis of Kieker monitoring data —
+ * reconstructing traces, computing performance metrics (e.g.,
+ * response times, throughput, error rates), and updating runtime
+ * architecture/dependency models in real time — via a TeeTime-based
+ * CLI pipeline that consumes live streams or log files and exports
+ * summaries and model artifacts for immediate diagnostics.
+ */
+module kieker.tools.runtime.analysis {
+}

--- a/tools/sar/build.gradle
+++ b/tools/sar/build.gradle
@@ -70,3 +70,10 @@ eclipse {
 		}
 	}
 }
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.sar=ALL-UNNAMED",
+	]
+}

--- a/tools/sar/src/module-info.java
+++ b/tools/sar/src/module-info.java
@@ -1,0 +1,21 @@
+/**
+ * This module provides a sar-like command-line reporter for
+ * Kieker resource-monitoring data—reading live streams or logs
+ * to summarize CPU, memory, load, network, and disk utilization
+ * over time, with options to filter intervals/metrics and export
+ * results for analysis.
+ */
+module kieker.tools.sar {
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires com.github.hazendaz.parent;
+    requires org.eclipse.emf.common;
+    requires org.eclipse.emf.ecore;
+    requires org.slf4j;
+}

--- a/tools/src/module-info.java
+++ b/tools/src/module-info.java
@@ -1,0 +1,48 @@
+/**
+ * This module provides the shared tooling layer and several
+ * CLI applications for Kieker—offering common parsers,
+ * converters, I/O and reporting utilities, plus entry points
+ * for tasks like model/architecture analysis and table/report
+ * generation—to process Kieker monitoring data and produce
+ * derived artifacts.
+ */
+module kieker.tools {
+
+    //Provided Packages
+    exports kieker.visualization.trace.dependency.graph;
+    exports kieker.visualization.trace.call.tree;
+    exports kieker.tools.source;
+    exports kieker.tools.common;
+    exports kieker.tools.settings;
+    exports kieker.tools.settings.converters;
+    exports kieker.tools.settings.validators;
+    exports kieker.tools.trace.analysis.filter;
+    exports kieker.tools.trace.analysis.repository;
+    exports kieker.tools.trace.analysis.systemModel;
+    exports kieker.tools.trace.analysis.filter.visualization;
+    exports kieker.visualization.trace;
+    exports kieker.tools.trace.analysis.systemModel.repository;
+    exports kieker.tools.trace.analysis.filter.executionRecordTransformation;
+    exports kieker.tools.trace.analysis.filter.flow;
+    exports kieker.tools.trace.analysis.filter.traceFilter;
+    exports kieker.tools.trace.analysis.filter.traceReconstruction;
+    exports kieker.tools.trace.analysis.filter.traceWriter;
+    exports kieker.tools.trace.analysis.filter.visualization.callTree;
+    exports kieker.tools.trace.analysis.filter.visualization.dependencyGraph;
+    exports kieker.tools.trace.analysis.filter.visualization.sequenceDiagram;
+    exports kieker.tools.trace.analysis.filter.visualization.descriptions;
+    exports kieker.tools.trace.analysis.filter.visualization.traceColoring;
+
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.monitoring.core;
+
+    //Java Dependencies
+    requires java.logging;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+}

--- a/tools/trace-analysis-gui/src/module-info.java
+++ b/tools/trace-analysis-gui/src/module-info.java
@@ -1,0 +1,21 @@
+/**
+ * This module provides a Swing-based, wizard-style GUI for
+ * configuring and launching Kieker trace analyses—letting
+ * users select input logs, set filters and output options
+ * (plots/reports), run the analysis, and manage/export
+ * results as a front end to the command-line
+ * trace-analysis tool.
+ */
+module kieker.tools.trace.analysis.gui {
+
+    //Kieker Dependencies
+    requires kieker.tools;
+    requires kieker.tools.trace.analysis;
+
+    //Java Dependencies
+    requires java.desktop;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+
+}

--- a/tools/trace-analysis/build.gradle
+++ b/tools/trace-analysis/build.gradle
@@ -49,3 +49,10 @@ eclipse {
 }
 
 compileJava.dependsOn replaceHardCodedVersionNames
+
+tasks.named("compileJava") {
+	options.compilerArgs += ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools=ALL-UNNAMED",
+							 '--add-reads', "kieker.tools.trace.analysis=ALL-UNNAMED",
+	]
+}

--- a/tools/trace-analysis/build.gradle
+++ b/tools/trace-analysis/build.gradle
@@ -9,7 +9,15 @@ targetCompatibility = 17
 distTar.enabled=false
 distZip.enabled=true
 
-mainClassName='kieker.tools.trace.analysis.TraceAnalysisToolMain'
+application {
+    mainModule = 'kieker.tools.trace.analysis'
+    mainClass = mainClassName='kieker.tools.trace.analysis.TraceAnalysisToolMain'
+    applicationDefaultJvmArgs = ['--add-reads', "kieker.analysis=ALL-UNNAMED",
+                                 '--add-reads', "kieker.tools=ALL-UNNAMED",
+                                 '--add-reads', "kieker.tools.trace.analysis=ALL-UNNAMED",
+                                 '--add-opens', "kieker.tools.trace.analysis/kieker.tools.trace.analysis=ALL-UNNAMED",
+    ]
+}
 
 sourceSets.main.resources.srcDirs = [ '../resources' ]
 

--- a/tools/trace-analysis/build.gradle
+++ b/tools/trace-analysis/build.gradle
@@ -11,7 +11,7 @@ distZip.enabled=true
 
 application {
     mainModule = 'kieker.tools.trace.analysis'
-    mainClass = mainClassName='kieker.tools.trace.analysis.TraceAnalysisToolMain'
+    mainClass = 'kieker.tools.trace.analysis.TraceAnalysisToolMain'
     applicationDefaultJvmArgs = ['--add-reads', "kieker.analysis=ALL-UNNAMED",
                                  '--add-reads', "kieker.tools=ALL-UNNAMED",
                                  '--add-reads', "kieker.tools.trace.analysis=ALL-UNNAMED",

--- a/tools/trace-analysis/src/module-info.java
+++ b/tools/trace-analysis/src/module-info.java
@@ -1,0 +1,24 @@
+/**
+ * This module analyzes Kieker monitoring logs to reconstruct
+ * end-to-end execution traces, derive call trees/graphs and
+ * service/operation dependencies, compute performance metrics
+ * (e.g., response times, trace statistics), and export
+ * reports/visualizations (e.g., sequence diagrams, dependency
+ * graphs) via both a CLI and a GUI-driven wizard.
+ */
+module kieker.tools.trace.analysis {
+
+    //Provided Packages
+    exports kieker.tools.trace.analysis;
+    exports kieker.tools.trace.analysis.filter.systemModel;
+
+
+    //Kieker Dependencies
+    requires kieker.analysis;
+    requires kieker.common;
+    requires kieker.model;
+    requires kieker.tools;
+
+    //Third Party Dependencies
+    requires org.slf4j;
+}


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Adds module-info files to all Gradle subprojects, effectively turning the subprojects into JPMS modules.
- Adapt the build.gradle files:
  - to handle dependencies for the module path (Kieker uses a lot of non-JPMS libraries and therefore needs to read the unnamed module) and some fixes
  - to make trace analysis use the module path and run as a module. (Only trace-analysis for now, as the other tools have not been tested yet)
  
  
## Open TODOs

- [ ] Update names of modules.