### PR TITLE
Alternative approach to make dummy asc files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
 
         stage('Distribution Build') {
           steps {
-            sh './gradlew -x test -x signMavenJavaPublication -x signArchives build publishToMavenLocal distribute'
+            sh './gradlew -x test -x signMavenJavaPublication build publishToMavenLocal distribute'
             sh 'bin/dev/assemble-tools.sh'
             stash includes: 'build/libs/*.jar', name: 'jarArtifacts'
             stash includes: 'build/distributions/*', name: 'distributions'
@@ -192,7 +192,7 @@ pipeline {
             }
           }
           steps {
-            sh './gradlew -x signMavenJavaPublication -x signArchives build publishToMavenLocal'
+            sh './gradlew -x signMavenJavaPublication build publishToMavenLocal'
             unstash 'distributions'
             sh 'bin/dev/release-check-extended.sh'
           }
@@ -272,7 +272,7 @@ pipeline {
                 passwordVariable: 'kiekerMavenPassword'
               )
             ]) {
-              sh './gradlew -x signMavenJavaPublication -x signArchives publish'
+              sh './gradlew -x signMavenJavaPublication publish'
             }
           }
           post {

--- a/build.gradle
+++ b/build.gradle
@@ -1151,33 +1151,6 @@ distribute.mustRunAfter enableRTests
 //signing.secretKeyRingFile=/home/USER/.gnupg/secring.gpg
 //
 
-ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-signing {
-  required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
-  sign configurations.archives
-}
-
-
-// This is necessary for the RC call, since in the regular non-RC stage, no signatory is configured in Jenkins, but for release-versions, Gradle still requires .asc files
-task createDummyAscFiles {
-  doLast {
-    if (isReleaseVersion) {
-      file('build/libs').listFiles().each { file ->
-        if (file.name.endsWith('.jar')) {
-          new File(file.path + '.asc').text = 'dummy'
-        }
-      }
-      println 'Created build/: ' + new File('build/').mkdir()
-      println 'Created build/publications/: ' + new File('build/publications/').mkdir()
-      println 'Created build/publications/mavenJava/: ' + new File('build/publications/mavenJava/').mkdir()
-      new File('build/publications/mavenJava/pom-default.xml.asc').text = 'dummy'
-    }
-  }
-}
-
-publishToMavenLocal.dependsOn createDummyAscFiles
-
-
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,3 +39,36 @@ include 'tools:trace-analysis-new'
 include 'extension-kafka'
 include 'extension-cassandra'
 include 'examples'
+
+// settings.gradle
+gradle.projectsEvaluated {
+    def rootProject = gradle.rootProject
+
+    def isPublishingToMavenLocal = gradle.startParameter.taskNames.any {
+        it == 'publishToMavenLocal' || it.endsWith('ToMavenLocal')
+    }
+
+    if (!isPublishingToMavenLocal) return
+
+    def isReleaseVersion = !rootProject.version.toString().endsWith("SNAPSHOT")
+
+    if (!isReleaseVersion) return
+
+    def libsDir = new File(rootProject.buildDir, 'libs')
+    libsDir.mkdirs()
+
+    rootProject.publishing.publications.each { pub ->
+        pub.artifacts
+            .findAll { it.extension != 'asc' }
+            .each { artifact ->
+                def ascFile = new File(artifact.file.path + '.asc')
+                if (!ascFile.exists()) {
+                    ascFile.text = 'dummy'
+                }
+            }
+
+        def pomDir = new File(rootProject.buildDir, "publications/${pub.name}")
+        pomDir.mkdirs()
+        new File(pomDir, 'pom-default.xml.asc').text = 'dummy'
+    }
+}


### PR DESCRIPTION
# Pull Request
PR for [[GH-10] Fix Release Process](https://github.com/kieker-monitoring/kieker/issues/2913): creation of dummy ASC files has been moved to `settings.gradle`. This will make sure all necessary ASC files are created before any jar creation/publishToMavenLocal tasks.

## Contribution
This pull request provides the following contribution to Kieker
- Proposes an alternative approach to create dummy ASC files
- Because we are now using `maven-publish`, we will not check neither `signArchives` nor `uploadArchives`.
- We could also think about having an explicit init gradle script https://docs.gradle.org/current/userguide/init_scripts.html In this case, we won't touch `settings.gradle`.