### PR TITLE
Constructor should be public

### DIFF
--- a/monitoring/core/src/kieker/monitoring/timer/ZeroTimer.java
+++ b/monitoring/core/src/kieker/monitoring/timer/ZeroTimer.java
@@ -27,7 +27,7 @@ import kieker.common.configuration.Configuration;
  */
 public class ZeroTimer extends AbstractTimeSource {
 
-	protected ZeroTimer(final Configuration configuration) {
+	public ZeroTimer(final Configuration configuration) {
 		super(configuration);
 	}
 


### PR DESCRIPTION
# Pull Request

## Contribution
This pull request provides the following contribution to Kieker
- Contribution 1 Make constructor `public`, otherwise, the timer is unusable


## Code Quality Thresholds
- [ ] It was necessary to raise any code quality thresholds
- If yes, which had to be raised and why was it necessary?
..
